### PR TITLE
prereqs/pips: Remove duplicate entries for Cython, grako

### DIFF
--- a/prereqs/pips/build_requirements.txt
+++ b/prereqs/pips/build_requirements.txt
@@ -1,14 +1,2 @@
-
 # used to manage package versions
 packaging==21.0
-
-#
-# Packages needed during the build process.
-# These are not installed in the ChimeraX app.
-#
-
-# Cython used by compile core/_serialize.pyx
-Cython==0.29.24
-
-# Grako used to make _atomspec.py parser from _atomspec.peg in core/commands
-grako==3.16.5


### PR DESCRIPTION
We install Cython and grako in `app_requirements.txt` and they are indeed in my environment and in users' bug reports. 