### PR TITLE
bundles/graphics: Correct bad import of LineType from chimerax.graphics

### DIFF
--- a/src/bundles/graphics/src/drawing.py
+++ b/src/bundles/graphics/src/drawing.py
@@ -1397,7 +1397,7 @@ class Drawing:
             print("%s<Appearance USE='%s'/>" % (tab, name), file=stream)
             return
 
-        from graphics.linetype import LineType
+        from chimerax.graphics.linetype import LineType
         print("%s<Appearance DEF='%s'>" % (tab, name), file=stream)
         if line_width != 1 or line_type != LineType.Solid:
             print("%s <LineProperties" % tab, end='', file=stream)


### PR DESCRIPTION
I think this is the right import, but I've never touched our graphical backends before so I'm not 100% sure. 