### PR TITLE
Fix array index bug in `measure mapvalues`

### DIFF
--- a/src/bundles/map/src/measure.py
+++ b/src/bundles/map/src/measure.py
@@ -129,8 +129,8 @@ def measure_map_values(session, map, atoms, attribute = 'mapvalue'):
                (map.name_with_id(), len(atoms), values.min(), values.max(),
                 values.mean(), values.std()))
     elif len(outside) < len(atoms):
-        from numpy import ones, uint8
-        inside = ones((len(atoms),), uint8)
+        from numpy import ones, bool_
+        inside = ones((len(atoms),), bool_)
         inside[outside] = 0
         v = values[inside]
         msg = ('Interpolated map %s values at %d atom positions (%d outside map bounds),'


### PR DESCRIPTION
Hi,

With `uint8`, `v = values[inside]` (in two lines from the last changed line) is only indexing either the 0-th or the 1-th element. 
This causes a bug when there are atoms outside the volume's bounding box. One such case is attached ([measure mapvalues bug.zip](https://github.com/user-attachments/files/17686454/measure.mapvalues.bug.zip)). 

This pull request fixes the bug by using `bool_`. 

