### PR TITLE
Catch exception on invalid distances in NMR-STAR file

### DIFF
--- a/src/bundles/nmrstar/src/nmrstar.py
+++ b/src/bundles/nmrstar/src/nmrstar.py
@@ -49,8 +49,7 @@ def read_nmr_star(session, path, name,
             continue
         constraint_loop = saveframe.get_loop('Gen_dist_constraint')
         clist = constraint_loop.get_tag(constraint_tag_names)
-        clist = [(cid1, int(rnum1), rname1, atom1, cid2, int(rnum2), rname2, atom2, float(dist_min), float(dist_max))
-                 for cid1, rnum1, rname1, atom1, cid2, rnum2, rname2, atom2, dist_min, dist_max in clist]
+        clist = [_parse_constraint(session, c) for c in clist]
         constraint_sets.append((constraint_type, clist))
 
     if structures is None:
@@ -72,6 +71,22 @@ def read_nmr_star(session, path, name,
     msg = f'Read NMR-STAR {basename(path)}, {descrip} applied to {len(structures)} structures'
     
     return [], msg	# Don't return models since they are already added to session
+
+# -----------------------------------------------------------------------------
+#
+def _parse_constraint(session, clist_item):
+    cid1, rnum1, rname1, atom1, cid2, rnum2, rname2, atom2, dist_min_raw, dist_max_raw = clist_item
+    try:
+        dist_min = float(dist_min_raw)
+    except ValueError as e:
+        session.logger.warning(f'Invalid minimum distance in {clist_item}; using fallback value (-1). Error message: "{str(e)}"')
+        dist_min = -1.0
+    try:
+        dist_max = float(dist_max_raw)
+    except ValueError as e:
+        session.logger.warning(f'Invalid maximum distance in {clist_item}; using fallback value (infinity). Error message: "{str(e)}"')
+        dist_max = float("inf")
+    return cid1, int(rnum1), rname1, atom1, cid2, int(rnum2), rname2, atom2, dist_min, dist_max
 
 # -----------------------------------------------------------------------------
 #


### PR DESCRIPTION
Hi,

I noticed that the NMRSTAR bundle raises an exception when any distance constraint in an NMR-STAR file does not contain "`float`-parseable" values for both the minimum and maximum distance. For example, [PDB entry 7SA5's restraint file](https://files.rcsb.org/pub/pdb/data/structures/divided/nmr_data/sa/7sa5_nmr-data.str.gz) contains only one distance for each constraint and uses `'.'` for the missing value, which means that one restraint is parsed as e.g. `['A', '49', 'GLN', 'H', 'A', '49', 'GLN', 'HB2', '.', '2.81']`. NMRSTAR tries to convert the `'.'` into a `float` for the restraint's minimum distance and immediately stops when the conversion raises an error. I believe it would be better not to directly raise an exception here, but to draw as many constraints as possible and just provide the user with warnings regarding invalid distances.

This patch catches each raised exception, logs it as a warning (automatically collated with any other output from the module) and falls back to a default value that ensures the invalid distance is never considered violated (`-1.0` for minimum distance, `float("inf")` for maximum distance). This means that each constraint with at least one valid distance is still drawn and that its representation can still be altered if the actual distance between its two atoms is longer than its (valid) maximum distance. However, if both the minimum and maximum distance of a constraint are invalid, the restraint is ignored entirely.