### PR TITLE
Prune the Brewfile

### DIFF
--- a/.github/workflows/rocky8_build.yml
+++ b/.github/workflows/rocky8_build.yml
@@ -89,7 +89,7 @@ jobs:
           command: curl -v -F "key=${{ secrets.PREBUILT_CACHE_SECRET }}" -F "commit=$BUILD_COMMIT" -F "date=$BUILD_DATE" -F "platform=centos-8" -F "build_type=${{ inputs.release_type }}" -F "file=@$GITHUB_WORKSPACE/chimerax.rpm" https://preview.rbvi.ucsf.edu/chimerax/cgi-bin/upload_build.py
       - name: Tar the docs directory
         run: |
-          rsync --delete -az --exclude user ChimeraX.app/share/docs chimerax-docs
+          rsync --delete -az --exclude user ChimeraX.app/share/docs/ chimerax-docs
           rsync --delete -az --copy-links vdocs/user chimerax-docs
           tar -cvzf chimerax-docs.tar.gz -C chimerax-docs/ .
       - name: Upload the documentation

--- a/utils/Brewfile
+++ b/utils/Brewfile
@@ -1,13 +1,3 @@
 # vim: syntax=config:
-brew "netcdf"
-brew "hdf5"    # tables
-brew "lz4"     # tables
-brew "c-blosc" # tables
 brew "autoconf"
 brew "automake"
-brew "libtool"
-# if installing scipy from source
-brew "openblas"
-brew "jq"
-
-brew "python@3.10"


### PR DESCRIPTION
It takes a few minutes to build and install the packages from the Brewfile, and I'm not sure they're useful anymore. This is a test of whether they're still needed to build certain PyPi packages. I'll close this without merging if the checks are unsuccessful. 