### PR TITLE
feature/scenes/viewstate-scene-interface

### DIFF
--- a/src/bundles/geometry/src/psession.py
+++ b/src/bundles/geometry/src/psession.py
@@ -1,5 +1,5 @@
 # === UCSF ChimeraX Copyright ===
-# Copyright 2016 Regents of the University of California.
+# Copyright 2025 Regents of the University of California.
 # All rights reserved.  This software provided pursuant to a
 # license agreement containing restrictions on its disclosure,
 # duplication and use.  For details see:

--- a/src/bundles/geometry/src/psession.py
+++ b/src/bundles/geometry/src/psession.py
@@ -39,8 +39,10 @@ class PlaceState:
 
     @staticmethod
     def restore_scene(place, session, data):
-        place.matrix = data['matrix']
-        place._is_identity = data['_is_identity']
+        from . import Place
+        new_place = Place(data['matrix'])
+        new_place._is_identity = data['_is_identity']
+        return new_place
 
 class PlacesState:
     version = 1

--- a/src/bundles/geometry/src/psession.py
+++ b/src/bundles/geometry/src/psession.py
@@ -40,9 +40,7 @@ class PlaceState:
     @staticmethod
     def restore_scene(place, session, data):
         from . import Place
-        new_place = Place(data['matrix'])
-        new_place._is_identity = data['_is_identity']
-        return new_place
+        return PlaceState.restore_snapshot(session, data)
 
 class PlacesState:
     version = 1

--- a/src/bundles/geometry/src/psession.py
+++ b/src/bundles/geometry/src/psession.py
@@ -37,6 +37,11 @@ class PlaceState:
         p._is_identity = data['_is_identity']
         return p
 
+    @staticmethod
+    def restore_scene(place, session, data):
+        place.matrix = data['matrix']
+        place._is_identity = data['_is_identity']
+
 class PlacesState:
     version = 1
 

--- a/src/bundles/graphics/src/gsession.py
+++ b/src/bundles/graphics/src/gsession.py
@@ -77,9 +77,6 @@ class ViewState:
             # stored in the View. For the simplicity of Scenes we want to convert all the nested objects into raw data.
             v_camera = v.camera
             data['camera'] = CameraState.take_snapshot(v_camera, session, State.SCENE)
-            c_position = v_camera.position
-            from chimerax.geometry.psession import PlaceState
-            data['camera']['position'] = PlaceState.take_snapshot(c_position, session, State.SCENE)
 
             v_lighting = v.lighting
             data['lighting'] = LightingState.take_snapshot(v_lighting, session, State.SCENE)
@@ -220,6 +217,13 @@ class CameraState:
             session.logger.info('"%s" camera settings not currently saved in sessions' % c.name)
             data = {'position': c.position}
         data['version'] = CameraState.version
+
+        # Scene Implementation
+        from chimerax.core.state import State
+        if flags == State.SCENE:
+            from chimerax.geometry.psession import PlaceState
+            data['position'] = PlaceState.take_snapshot(c.position, session, State.SCENE)
+
         return data
 
     @staticmethod

--- a/src/bundles/graphics/src/gsession.py
+++ b/src/bundles/graphics/src/gsession.py
@@ -249,6 +249,11 @@ class CameraState:
     def reset_state(camera, session):
         pass
 
+    @staticmethod
+    def restore_scene(camera, session, data):
+        from chimerax.geometry.psession import PlaceState
+        PlaceState.restore_scene(camera.position, session, data['position'])
+        CameraState.set_state_from_snapshot(camera, session, data)
 
 class LightingState:
 

--- a/src/bundles/graphics/src/gsession.py
+++ b/src/bundles/graphics/src/gsession.py
@@ -308,6 +308,7 @@ class LightingState:
     @staticmethod
     def restore_scene(lighting, session, data):
         LightingState.set_state_from_snapshot(lighting, session, data)
+        return lighting
 
 class MaterialState:
 

--- a/src/bundles/graphics/src/gsession.py
+++ b/src/bundles/graphics/src/gsession.py
@@ -346,6 +346,9 @@ class MaterialState:
     def reset_state(Material, session):
         pass
 
+    @staticmethod
+    def restore_scene(material, session, data):
+        MaterialState.set_state_from_snapshot(material, session, data)
 
 class ClipPlaneState:
     '''This is no longer used for saving sessions but is kept for restoring old sessions.'''

--- a/src/bundles/graphics/src/gsession.py
+++ b/src/bundles/graphics/src/gsession.py
@@ -250,10 +250,11 @@ class CameraState:
         pass
 
     @staticmethod
-    def restore_scene(camera, session, data):
+    def restore_scene(c, session, data):
         from chimerax.geometry.psession import PlaceState
-        PlaceState.restore_scene(camera.position, session, data['position'])
-        CameraState.set_state_from_snapshot(camera, session, data)
+        data['position']= PlaceState.restore_scene(c.position, session, data['position'])
+        CameraState.set_state_from_snapshot(c, session, data)
+        return c
 
 class LightingState:
 

--- a/src/bundles/graphics/src/gsession.py
+++ b/src/bundles/graphics/src/gsession.py
@@ -75,31 +75,25 @@ class ViewState:
         if flags == State.SCENE:
             # By default, ViewState take_snapshot uses class name references and uids to store data for object attrs
             # stored in the View. For the simplicity of Scenes we want to convert all the nested objects into raw data.
-            v_camera = v.camera
-            data['camera'] = CameraState.take_snapshot(v_camera, session, State.SCENE)
+            data['camera'] = CameraState.take_snapshot(v.camera, session, State.SCENE)
 
-            v_lighting = v.lighting
-            data['lighting'] = LightingState.take_snapshot(v_lighting, session, State.SCENE)
+            data['lighting'] = LightingState.take_snapshot(v.lighting, session, State.SCENE)
 
-            v_material = v.material
-            data['material'] = MaterialState.take_snapshot(v_material, session, State.SCENE)
+            data['material'] = MaterialState.take_snapshot(v.material, session, State.SCENE)
 
-            # 'clip_planes in data is an array of clip planes objects. The clip plane objects can be either scene or
-            # camera clip planes. Need to convert them into raw data before storing them in the scene, but also need
-            # to keep track of which state class the data was derived from, so it can be restored. This is done by
-            # storing a tuple of a state class identifier and the raw data.
             clip_planes = data['clip_planes']
             clip_planes_data = []
             for clip_pane in clip_planes:
+                # Track the type of clip plane state so it can be restored correctly.
                 cp_state_manager = session.snapshot_methods(clip_pane)
                 if cp_state_manager == CameraClipPlaneState:
-                    clip_planes_data.append(
-                        ("camera", CameraClipPlaneState.take_snapshot(clip_pane, session, State.SCENE)))
-                if cp_state_manager == SceneClipPlaneState:
-                    clip_planes_data.append(
-                        ("scene", SceneClipPlaneState.take_snapshot(clip_pane, session, State.SCENE)))
-
+                    cp_data = ('camera', cp_state_manager.take_snapshot(clip_pane, session, State.SCENE))
+                else:
+                    cp_data = ('scene', cp_state_manager.take_snapshot(clip_pane, session, State.SCENE))
+                clip_planes_data.append(cp_data)
             data['clip_planes'] = clip_planes_data
+
+            # End scene implementation. Object references in the snapshot have all been converted to raw data.
 
         return data
 
@@ -111,34 +105,27 @@ class ViewState:
         return v
 
     @staticmethod
-    def restore_scene(session, scene_data):
+    def restore_scene(view, session, scene_data):
         """
         Scenes interface implementation
         """
-        from chimerax.geometry.psession import PlaceState
-        scene_data['camera']['position'] = PlaceState.restore_snapshot(session, scene_data['camera']['position'])
-        scene_data['camera'] = CameraState.restore_snapshot(session, scene_data['camera'])
-        scene_data['lighting'] = LightingState.restore_snapshot(session, scene_data['lighting'])
-        scene_data['material'] = MaterialState.restore_snapshot(session, scene_data['material'])
+        scene_data['camera'] = CameraState.restore_scene(view.camera, session, scene_data['camera'])
+        scene_data['lighting'] = LightingState.restore_scene(view.lighting, session, scene_data['lighting'])
+        scene_data['material'] = MaterialState.restore_scene(view.material, session, scene_data['material'])
 
-        # Restore the clip planes. The 'clip_planes' key in restore_data is an array of clip planes objects in snapshot
-        # form. We need to convert them back into CameraClipPlane objects before restoring the main view data.
-        clip_planes_data = scene_data['clip_planes']
-        restored_clip_planes = []
-        for clip_plane_type, clip_plane_data in clip_planes_data:
-            if clip_plane_type == "camera":
-                restored_clip_planes.append(CameraClipPlaneState.restore_snapshot(session, clip_plane_data))
-            if clip_plane_type == "scene":
-                restored_clip_planes.append(SceneClipPlaneState.restore_snapshot(session, clip_plane_data))
-
-        scene_data['clip_planes'] = restored_clip_planes
+        clip_planes = []    # Restored clip planes objects
+        for cp_data in scene_data['clip_planes']:
+            # cp_data is tuple(state type, state data)
+            cp = CameraClipPlaneState if cp_data[0] == 'camera' else SceneClipPlaneState
+            cp = cp.restore_scene(None, session, cp_data[1])
+            clip_planes.append(cp)
+        scene_data['clip_planes'] = clip_planes
 
         # The ViewState by default skips resetting the camera because session.restore_options.get('restore camera')
-        # is None. We set it to True, let the camera be restored, and then delete the option, so it reads None again in
-        # case it is an important option for other parts of the code.
+        # is None. Set it to True, let the camera be restored, and then delete the option, so it reads None again.
 
         session.restore_options['restore camera'] = True
-        ViewState.restore_snapshot(session, scene_data)
+        ViewState.set_state_from_snapshot(view, session, scene_data)
         del session.restore_options['restore camera']
 
     @staticmethod

--- a/src/bundles/graphics/src/gsession.py
+++ b/src/bundles/graphics/src/gsession.py
@@ -128,6 +128,8 @@ class ViewState:
         ViewState.set_state_from_snapshot(view, session, scene_data)
         del session.restore_options['restore camera']
 
+        return view
+
     @staticmethod
     def set_state_from_snapshot(view, session, data):
         v = view

--- a/src/bundles/graphics/src/gsession.py
+++ b/src/bundles/graphics/src/gsession.py
@@ -350,6 +350,7 @@ class MaterialState:
     @staticmethod
     def restore_scene(material, session, data):
         MaterialState.set_state_from_snapshot(material, session, data)
+        return material
 
 class ClipPlaneState:
     '''This is no longer used for saving sessions but is kept for restoring old sessions.'''

--- a/src/bundles/graphics/src/gsession.py
+++ b/src/bundles/graphics/src/gsession.py
@@ -1,7 +1,7 @@
 # vim: set expandtab shiftwidth=4 softtabstop=4:
 
 # === UCSF ChimeraX Copyright ===
-# Copyright 2022 Regents of the University of California. All rights reserved.
+# Copyright 2025 Regents of the University of California. All rights reserved.
 # The ChimeraX application is provided pursuant to the ChimeraX license
 # agreement, which covers academic and commercial uses. For more details, see
 # <https://www.rbvi.ucsf.edu/chimerax/docs/licensing.html>

--- a/src/bundles/graphics/src/gsession.py
+++ b/src/bundles/graphics/src/gsession.py
@@ -426,9 +426,7 @@ class SceneClipPlaneState:
 
     @staticmethod
     def restore_scene(cp, session, data):
-        cp.name = data['name']
-        cp.normal = data['normal']
-        cp.plane_point = data['plane_point']
+        return SceneClipPlaneState.restore_snapshot(session, data)
 
 class CameraClipPlaneState:
     
@@ -459,9 +457,7 @@ class CameraClipPlaneState:
 
     @staticmethod
     def restore_scene(cp, session, data):
-        cp.name = data['name']
-        cp._camera_normal = data['_camera_normal']
-        cp._camera_plane_point = data['_camera_plane_point']
+        return CameraClipPlaneState.restore_snapshot(session, data)
 
 class DrawingState:
 

--- a/src/bundles/graphics/src/gsession.py
+++ b/src/bundles/graphics/src/gsession.py
@@ -421,6 +421,11 @@ class SceneClipPlaneState:
     def reset_state(clip_plane, session):
         pass
 
+    @staticmethod
+    def restore_scene(cp, session, data):
+        cp.name = data['name']
+        cp.normal = data['normal']
+        cp.plane_point = data['plane_point']
 
 class CameraClipPlaneState:
     
@@ -449,6 +454,11 @@ class CameraClipPlaneState:
     def reset_state(clip_plane, session):
         pass
 
+    @staticmethod
+    def restore_scene(cp, session, data):
+        cp.name = data['name']
+        cp._camera_normal = data['_camera_normal']
+        cp._camera_plane_point = data['_camera_plane_point']
 
 class DrawingState:
 

--- a/src/bundles/graphics/src/gsession.py
+++ b/src/bundles/graphics/src/gsession.py
@@ -305,6 +305,9 @@ class LightingState:
     def reset_state(lighting, session):
         pass
 
+    @staticmethod
+    def restore_scene(lighting, session, data):
+        LightingState.set_state_from_snapshot(lighting, session, data)
 
 class MaterialState:
 

--- a/src/bundles/scenes/src/scene.py
+++ b/src/bundles/scenes/src/scene.py
@@ -66,6 +66,20 @@ class Scene(State):
     instead of super().take_snapshot(State.SCENE) to ensure you are calling a Scene supported parent class.
 
     - Model positions are saved by the NamedView object and do not need to be saved in Scene interface implementations.
+
+    How to implement Scene support for a static state managing class:
+
+    1) Implement static take_snapshot(obj, session, flags=State.SCENE). obj is the object that the snapshot should be
+    taken from, session is the current session, and flags is the State flag that is passed to take_snapshot. The flags
+    argument will be State.SCENE when taking a scene snapshot. take_snapshot should return a dictionary of data that is
+    needed to capture any scene relevant state data.
+
+    2) Implement static restore_scene(obj, session, data). Obj is the object that the snapshot was taken from, session
+    is the current session, and data is the dictionary that was returned from
+    take_snapshot(obj, session, flags=State.SCENE). This method is expected to return an object that is assumed to have
+    the scene state data applied to it.
+
+    Note: Static state managing classes are not automatically to the scene snapshot system.
     """
 
     version = 0

--- a/src/bundles/scenes/src/scene.py
+++ b/src/bundles/scenes/src/scene.py
@@ -143,7 +143,7 @@ class Scene(State):
         main_view = self.session.view
         view_state = self.session.snapshot_methods(main_view)
         if implements_scene(view_state):
-            view_state.restore_scene(self.session, copy.deepcopy(self.main_view_data))
+            view_state.restore_scene(main_view, self.session, copy.deepcopy(self.main_view_data))
         current_models = self.session.models.list()
         for model in current_models:
             # NamedView only handles restoring model positions. Camera and clip plane positions are restored with the


### PR DESCRIPTION
# Refactor: Scene Interface in ViewState

## Summary  
This PR refactors scene saving for the ViewState and it's attributes. It improves adherence to the project's API standards by ensuring that each state handles its own scene `take_snapshot` and `restore_scene` logic. 

## Key Changes  

### Static Class Scene API
- `take_snapshot(obj, session, flags=State.SCENE)`: `obj` is the object that the snapshot should be
    taken from, `session` is the current session, and `flags` is the State flag. The flags
    argument will be State.SCENE when taking a scene snapshot. `take_snapshot` should return a dictionary of data that is
    needed to capture any scene relevant state data for the `obj`.
- `restore_scene(obj, session, data)`: `obj` is the object that the snapshot was taken from, `session`
    is the current session, and `data` is the dictionary that was returned from
    `take_snapshot`. This method is must return an object that has
    the scene state data applied to it. It is up to the implementation if it uses the `obj` argument instance or creates a new instance.

### ViewState  
- Handles `restore_scene` calls for all its attributes (camera, lighting, material, clip planes).  
- Adjusts `take_snapshot` to properly serialize nested objects for scene storage.  
- Uses a reference to the session's main view instead of creating a new view instance.  

### CameraState  
- `take_snapshot`: Now directly manages `State.SCENE` flag and calls down to `PlacesState` for position handling.  
- `restore_scene`: Restores camera position state using `PlaceState.restore_scene`, then applies `set_state_from_snapshot` and does not create new camera instance.  

### PlaceState  
- Implements `restore_scene`.  Uses `restore_snapshot`. Does create new Place instance.

### LightingState & MaterialState  
- `restore_scene`: Uses `set_state_from_snapshot` to restore. Do not create new instances.

### Clip Plane States (Scene & Camera)  
- `restore_scene`: Uses `restore_snapshot` to return new clip plane instances.

## Cleanup  
- Updates documentation for the scene API in static state managers.  
- Updates license headers.