### PR TITLE
feature/viewdock/starting-tool

### DIFF
--- a/src/bundles/viewdock/src/__init__.py
+++ b/src/bundles/viewdock/src/__init__.py
@@ -7,7 +7,7 @@ class _MyAPI(BundleAPI):
     @staticmethod
     def start_tool(session, bi, ti):
         if ti.name == "ViewDock":
-            # TODO file open dialogue here
+            show_docking_file_dialogue(session)
             pass
 
     @staticmethod
@@ -62,6 +62,22 @@ class _MyAPI(BundleAPI):
         return ViewDockOpenerInfo()
 
 bundle_api = _MyAPI()
+
+def show_docking_file_dialogue(session):
+    """
+    Show an open file dialogue specifically for docking results formats.
+    """
+
+    docking_formats_names = []
+    for data_format in session.data_formats.formats:
+        if data_format.category == "Docking results":
+            docking_formats_names.append(data_format.name)
+    if not docking_formats_names:
+        session.logger.warning("No docking results formats found.")
+        return
+    from chimerax.open_command import show_open_file_dialog
+    show_open_file_dialog(session, format_names=docking_formats_names)
+
 
 def open_viewdock_tool(session, structures=None):
     """

--- a/src/bundles/viewdock/src/__init__.py
+++ b/src/bundles/viewdock/src/__init__.py
@@ -7,9 +7,8 @@ class _MyAPI(BundleAPI):
     @staticmethod
     def start_tool(session, bi, ti):
         if ti.name == "ViewDock":
-            from .tool import ViewDockTool
-            tool = ViewDockTool(session, ti.name)
-            return tool
+            # TODO file open dialogue here
+            pass
 
     @staticmethod
     def register_command(bi, ci, logger):
@@ -66,22 +65,12 @@ bundle_api = _MyAPI()
 
 def open_viewdock_tool(session, structures=None):
     """
-    Open the ViewDock tool for the given structures. If no structures are given, the tool will handle finding them.
+    Open the ViewDock tool for the given structures.
 
     Args:
         session: the ChimeraX session
         structures: a list of structures to open in the tool
     """
 
-    toolshed = session.toolshed
-
-    bi = toolshed.find_bundle("ViewDock", session.logger)
-
-    if bi is None:
-        session.logger.error("Cannot open ViewDock tool because bundle was not found.")
-        return
-
-    vd_tool = bi.start_tool(session, "ViewDock")
-    vd_tool.setup(structures)
-
-    # TODO update tool with structures
+    from .tool import ViewDockTool
+    tool = ViewDockTool(session, "ViewDock", structures)

--- a/src/bundles/viewdock/src/__init__.py
+++ b/src/bundles/viewdock/src/__init__.py
@@ -79,14 +79,17 @@ def show_docking_file_dialogue(session):
     show_open_file_dialog(session, format_names=docking_formats_names)
 
 
-def open_viewdock_tool(session, structures=None):
+def open_viewdock_tool(session, structures):
     """
     Open the ViewDock tool for the given structures.
 
     Args:
-        session: the ChimeraX session
-        structures: a list of structures to open in the tool
+        session (Session): the ChimeraX session.
+        structures (list): A list of structures to open in the tool.
     """
 
+    if not structures:
+        session.logger.warning("Cannot open ViewDock without providing docking structures.")
+        return
     from .tool import ViewDockTool
-    tool = ViewDockTool(session, "ViewDock", structures)
+    ViewDockTool(session, "ViewDock", structures)

--- a/src/bundles/viewdock/src/__init__.py
+++ b/src/bundles/viewdock/src/__init__.py
@@ -1,5 +1,4 @@
 from chimerax.core.toolshed import BundleAPI
-from chimerax.atomic import AtomicStructure
 
 class _MyAPI(BundleAPI):
     api_version = 1
@@ -8,7 +7,6 @@ class _MyAPI(BundleAPI):
     def start_tool(session, bi, ti):
         if ti.name == "ViewDock":
             show_docking_file_dialogue(session)
-            pass
 
     @staticmethod
     def register_command(bi, ci, logger):

--- a/src/bundles/viewdock/src/__init__.py
+++ b/src/bundles/viewdock/src/__init__.py
@@ -51,10 +51,7 @@ class _MyAPI(BundleAPI):
                         show_dock = False
                     if show_dock:
                         from Qt.QtCore import QTimer
-                        from chimerax.core.commands import run, concise_model_spec
-                        QTimer.singleShot(0,
-                            lambda *args, run=run, ses=session, spec=concise_model_spec, models=models:
-                                run(ses, "viewdock %s" % spec(ses, models)))
+                        QTimer.singleShot(0, lambda s=session, m=models: open_viewdock_tool(s, m))
                 return models, status
 
             @property
@@ -65,3 +62,17 @@ class _MyAPI(BundleAPI):
         return ViewDockOpenerInfo()
 
 bundle_api = _MyAPI()
+
+def open_viewdock_tool(session, structures=None):
+    """
+    Open the ViewDock tool for the given structures. If no structures are given, the tool will handle finding them.
+
+    Args:
+        session: the ChimeraX session
+        structures: a list of structures to open in the tool
+    """
+    toolshed = session.toolshed
+
+    bi = toolshed.find_bundle("ViewDock", session.logger)
+    bi.start_tool(session, "ViewDock")
+

--- a/src/bundles/viewdock/src/__init__.py
+++ b/src/bundles/viewdock/src/__init__.py
@@ -1,4 +1,5 @@
 from chimerax.core.toolshed import BundleAPI
+from chimerax.atomic import AtomicStructure
 
 class _MyAPI(BundleAPI):
     api_version = 1
@@ -71,8 +72,16 @@ def open_viewdock_tool(session, structures=None):
         session: the ChimeraX session
         structures: a list of structures to open in the tool
     """
+
     toolshed = session.toolshed
 
     bi = toolshed.find_bundle("ViewDock", session.logger)
-    bi.start_tool(session, "ViewDock")
 
+    if bi is None:
+        session.logger.error("Cannot open ViewDock tool because bundle was not found.")
+        return
+
+    vd_tool = bi.start_tool(session, "ViewDock")
+    vd_tool.setup(structures)
+
+    # TODO update tool with structures

--- a/src/bundles/viewdock/src/tool.py
+++ b/src/bundles/viewdock/src/tool.py
@@ -5,14 +5,16 @@ class ViewDockTool(ToolInstance):
     SESSION_ENDURING = False
     SESSION_SAVE = True
 
-    def __init__(self, session, tool_name):
+    def __init__(self, session, tool_name, structures):
         super().__init__(session, tool_name)
         self.display_name = "ViewDock"
 
         from chimerax.ui import MainToolWindow
         self.tool_window = MainToolWindow(self)
 
+        self.setup(structures)
+
         self.tool_window.manage('side')
 
     def setup(self, structures):
-        self.sessionlogging.info("ViewDockTool.setup")
+        self.session.logger.info(f"ViewDockTool setup with structures: {structures}")

--- a/src/bundles/viewdock/src/tool.py
+++ b/src/bundles/viewdock/src/tool.py
@@ -13,3 +13,6 @@ class ViewDockTool(ToolInstance):
         self.tool_window = MainToolWindow(self)
 
         self.tool_window.manage('side')
+
+    def setup(self, structures):
+        self.sessionlogging.info("ViewDockTool.setup")


### PR DESCRIPTION
# Starting ViewDock Tool

There are two entry points to open the ViewDock tool.

### Open Provider Start
`open_view_dock_tool(session, structures)`: This function should be called in the open providers for docking results formats. It expects to be passed the session and a list of structures that the provider created.

### Tool Menu Start
`show_docking_file_dialogue`: This function is called through the bundle API's `start_tool` to handle opening the tool when selected from the tool menu. It searches `session.data_formats` for any formats that have a `"Docking results"` category, and lists those formats in an file open dialogue.

Using the file open dialogue will route starting the tool through an open provider start as described above.
