### PR TITLE
feature/viewdock/rating-docking-results

### DIFF
--- a/src/bundles/viewdock/src/tool.py
+++ b/src/bundles/viewdock/src/tool.py
@@ -22,11 +22,10 @@
 
 from chimerax.core.tools import ToolInstance
 from chimerax.ui.widgets import ItemTable
-from Qt.QtWidgets import QVBoxLayout
 from chimerax.core.commands import run
 from chimerax.core.models import REMOVE_MODELS
-from Qt.QtWidgets import QStyledItemDelegate, QComboBox
-from Qt.QtWidgets import QAbstractItemView
+from Qt.QtWidgets import QStyledItemDelegate, QComboBox, QAbstractItemView, QVBoxLayout, QStyle, QStyleOptionComboBox
+from Qt.QtCore import Qt, QTimer
 
 class ViewDockTool(ToolInstance):
 
@@ -64,7 +63,7 @@ class ViewDockTool(ToolInstance):
 
         # Custom Rating delegate
         delegate = RatingDelegate(self.struct_table)  # Create the delegate instance
-        self.struct_table.add_column('Rating', lambda s: s.viewdockx_data.get('Rating', "1"),
+        self.struct_table.add_column('Rating', lambda s: s.viewdockx_data.get('Rating', "2"),
                                      data_set = lambda item, value: None,
                                      editable=True)
 
@@ -198,3 +197,20 @@ class RatingDelegate(QStyledItemDelegate):
             index: The index of the item in the model.
         """
         editor.setGeometry(option.rect)
+
+    def paint(self, painter, option, index):
+        """Always display a combo box UI rendering in the table."""
+
+        # Retrieve the latest value, prioritizing the edit role if available, otherwise use the display role.
+        # The edit role means combobox editor is open and display role means only being rendered in the table.
+        value = index.data(Qt.EditRole) or index.data(Qt.DisplayRole)
+
+        # Draw combo box appearance
+        style = option.widget.style()
+        combo_style = QStyleOptionComboBox()
+        combo_style.rect = option.rect
+        combo_style.currentText = str(value) if value else "2"  # Ensure there's always text
+        combo_style.state = QStyle.State_Enabled
+
+        style.drawComplexControl(QStyle.CC_ComboBox, combo_style, painter)
+        style.drawControl(QStyle.CE_ComboBoxLabel, combo_style, painter)

--- a/src/bundles/viewdock/src/tool.py
+++ b/src/bundles/viewdock/src/tool.py
@@ -64,7 +64,9 @@ class ViewDockTool(ToolInstance):
 
         # Custom Rating delegate
         delegate = RatingDelegate(self.struct_table)  # Create the delegate instance
-        self.struct_table.add_column('Rating', lambda s: s.viewdockx_data.get('Rating', 1))
+        self.struct_table.add_column('Rating', lambda s: s.viewdockx_data.get('Rating', "1"),
+                                     data_set = lambda item, value: None,
+                                     editable=True)
 
         # Associate the delegate with the "Rating" column
         rating_column_index = self.struct_table.column_names.index('Rating')

--- a/src/bundles/viewdock/src/tool.py
+++ b/src/bundles/viewdock/src/tool.py
@@ -139,32 +139,60 @@ class ViewDockTool(ToolInstance):
 
 class RatingDelegate(QStyledItemDelegate):
     def __init__(self, parent=None):
+        """
+        Initialize the RatingDelegate with a list of items for the QComboBox.
+
+        Args:
+            parent: The parent widget for the delegate.
+        """
         super().__init__(parent)
         self.items = ["1", "2", "3"]  # or ["Red", "Yellow", "Green"]
 
-    def createEditor(self, parent, QWidget=None, *args, **kwargs):
+    def createEditor(self, parent, option, index):
         """
-        Qt header: createEditor(self, parent, option, index)
+        Create and return a QComboBox editor for the delegate.
+
+        Args:
+            parent: The parent widget for the editor.
+            option: The style options for the item.
+            index: The index of the item in the model.
+
+        Returns:
+            QComboBox: The editor widget (QComboBox).
         """
         editor = QComboBox(parent)
         editor.addItems(self.items)
         return editor
 
-    def setEditorData(self, editor, QWidget=None, *args, **kwargs):
+    def setEditorData(self, editor, index):
         """
-        Qt header: setEditorData(self, editor, index)
+        Set the data from the model into the QComboBox editor.
+
+        Args:
+            editor: The editor widget (QComboBox).
+            index: The index of the item in the model.
         """
-        value = kwargs['index'].data()
+        value = index.data()
         editor.setCurrentText(value)
 
-    def setModelData(self, editor, QWidget=None, *args, **kwargs):
+    def setModelData(self, editor, model, index):
         """
-        Qt header: setModelData(self, editor, model, index)
-        """
-        kwargs['model'].setData(kwargs['index'], editor.currentText())
+        Set the data from the QComboBox editor back into the model.
 
-    def updateEditorGeometry(self, editor, QWidget=None, *args, **kwargs):
+        Args:
+            editor: The editor widget (QComboBox).
+            model: The model to set the data into.
+            index: The index of the item in the model.
         """
-        Qt header: updateEditorGeometry(self, editor, option, index)
+        model.setData(index, editor.currentText())
+
+    def updateEditorGeometry(self, editor, option, index):
         """
-        editor.setGeometry(kwargs['option'].rect)
+        Update the geometry of the QComboBox editor to match the item.
+
+        Args:
+            editor: The editor widget (QComboBox).
+            option: The style options for the item.
+            index: The index of the item in the model.
+        """
+        editor.setGeometry(option.rect)

--- a/src/bundles/viewdock/src/tool.py
+++ b/src/bundles/viewdock/src/tool.py
@@ -53,8 +53,9 @@ class ViewDockTool(ToolInstance):
     def table_setup(self):
         """
         Create the ItemTable for the structures. Add a column for the display with check boxes, a column for the
-        structure ID, and columns for each key in the viewdockx_data attribute of each structure
-        (ie Name, Description, Energy Score...). If a structure does not have a key from the set, the cell will be empty.
+        structure ID, a column for the Rating with a custom delegate, and columns for each key in the viewdockx_data
+        attribute of each structure (e.g., Name, Description, Energy Score...). If a structure does not have a key from
+        the set, the cell will be empty.
         """
 
         # Fixed columns. Generic based on ChimeraX model attributes.
@@ -71,14 +72,14 @@ class ViewDockTool(ToolInstance):
         rating_column_index = self.struct_table.column_names.index('Rating')
         self.struct_table.setItemDelegateForColumn(rating_column_index, delegate)
 
+        # Set an edit trigger for the table whenever the current selected item changes. Prevents having to click through
+        # multiple selections to edit the rating of a structure.
         self.struct_table.setEditTriggers(QAbstractItemView.EditTrigger.CurrentChanged)
 
-        # Collect all unique keys from viewdockx_data of all structures
+        # Collect all unique keys from viewdockx_data of all structures and add them as columns
         viewdockx_keys = set()
         for structure in self.structures:
             viewdockx_keys.update(structure.viewdockx_data.keys())
-
-        # Dynamically add columns for each unique key in viewdockx_data
         for key in viewdockx_keys:
             self.struct_table.add_column(key, lambda s, k=key: s.viewdockx_data.get(k, ''))
 

--- a/src/bundles/viewdock/src/tool.py
+++ b/src/bundles/viewdock/src/tool.py
@@ -25,7 +25,7 @@ from chimerax.ui.widgets import ItemTable
 from chimerax.core.commands import run
 from chimerax.core.models import REMOVE_MODELS
 from Qt.QtWidgets import QStyledItemDelegate, QComboBox, QAbstractItemView, QVBoxLayout, QStyle, QStyleOptionComboBox
-from Qt.QtCore import Qt, QTimer
+from Qt.QtCore import Qt
 
 class ViewDockTool(ToolInstance):
 

--- a/src/bundles/viewdock/src/tool.py
+++ b/src/bundles/viewdock/src/tool.py
@@ -204,14 +204,23 @@ class RatingDelegate(QStyledItemDelegate):
 
     def setModelData(self, editor, model, index):
         """
-        Set the data from the QComboBox editor back into the model.
+        Set the data from the QComboBox editor back into the ChimeraX Model (not the QAbstractItemModel). The ItemTable
+        will always call the paint method of the delegate using its own data_fetch which accesses attributes from a
+        chimerax model, not a qt table model. We need to set the data on the AtomicStructure and let the ItemTable
+        handle giving this delegates paint the correct data.
 
         Args:
             editor: The editor widget (QComboBox).
             model: The model to set the data into.
             index: The index of the item in the model.
         """
-        model.setData(index, editor.currentText())
+        # Get the structure (chimerax Structure) from the table row.
+        structure = self.parent().data[index.row()]
+        new_rating = editor.currentText()
+        structure.viewdockx_data['Rating'] = new_rating  # Update the rating in the structure's data
+
+        model.setData(index, new_rating)  # Optionally, set the value in the model too. This is for Qt completeness
+
 
     def updateEditorGeometry(self, editor, option, index):
         """

--- a/src/bundles/viewdock/src/tool.py
+++ b/src/bundles/viewdock/src/tool.py
@@ -198,8 +198,10 @@ class RatingDelegate(QStyledItemDelegate):
             editor: The editor widget (QComboBox).
             index: The index of the item in the model.
         """
-        value = index.data()
-        editor.setCurrentText(value)
+        value = index.data(Qt.EditRole) or index.data(Qt.DisplayRole)
+        i = editor.findText(str(value))
+        if i >= 0:
+            editor.setCurrentIndex(i)
 
     def setModelData(self, editor, model, index):
         """

--- a/src/bundles/viewdock/src/tool.py
+++ b/src/bundles/viewdock/src/tool.py
@@ -71,8 +71,7 @@ class ViewDockTool(ToolInstance):
         rating_column_index = self.struct_table.column_names.index('Rating')
         self.struct_table.setItemDelegateForColumn(rating_column_index, delegate)
 
-        # Ensure the table's edit triggers are set to allow editing
-        self.struct_table.setEditTriggers(QAbstractItemView.EditTrigger.DoubleClicked | QAbstractItemView.EditTrigger.SelectedClicked)
+        self.struct_table.setEditTriggers(QAbstractItemView.EditTrigger.CurrentChanged)
 
         # Collect all unique keys from viewdockx_data of all structures
         viewdockx_keys = set()

--- a/src/bundles/viewdock/src/tool.py
+++ b/src/bundles/viewdock/src/tool.py
@@ -64,7 +64,7 @@ class ViewDockTool(ToolInstance):
 
         # Custom Rating delegate
         delegate = RatingDelegate(self.struct_table)  # Create the delegate instance
-        self.struct_table.add_column('Rating', lambda s: s.viewdockx_data.get('Rating', "2"),
+        self.struct_table.add_column('Rating', lambda s: s.viewdockx_data.get('Rating', 2),
                                      data_set = lambda item, value: None,
                                      editable=True)
 
@@ -202,7 +202,7 @@ class RatingDelegate(QStyledItemDelegate):
         """
         # Get the structure (chimerax Structure) from the table row.
         structure = self.parent().data[index.row()]
-        new_rating = editor.currentText()
+        new_rating = int(editor.currentText())
         structure.viewdockx_data['Rating'] = new_rating  # Update the rating in the structure's data
 
         model.setData(index, new_rating)  # Optionally, set the value in the model too. This is for Qt completeness

--- a/src/bundles/viewdock/src/tool.py
+++ b/src/bundles/viewdock/src/tool.py
@@ -139,6 +139,31 @@ class ViewDockTool(ToolInstance):
 
 
 class RatingDelegate(QStyledItemDelegate):
+    """
+    A delegate that provides a QComboBox editor for editing ratings in a table view.
+
+    The RatingDelegate class is responsible for rendering a combo box in the table view and handling the interaction
+    between the editor widget (QComboBox) and the model. It ensures that the combo box is displayed correctly both
+    when the cell is selected and not selected, and that the data is properly committed to the model when editing
+    is finished.
+
+    Methods:
+        createEditor(parent, option, index):
+            Creates and returns a QComboBox editor for the delegate.
+
+        setEditorData(editor, index):
+            Sets the data from the model into the QComboBox editor.
+
+        setModelData(editor, model, index):
+            Sets the data from the QComboBox editor back into the model.
+
+        updateEditorGeometry(editor, option, index):
+            Updates the geometry of the QComboBox editor to match the item.
+
+        paint(painter, option, index):
+            Renders the combo box UI in the table view, ensuring the text is displayed correctly.
+    """
+
     def __init__(self, parent=None):
         """
         Initialize the RatingDelegate with a list of items for the QComboBox.


### PR DESCRIPTION
## Feature: ViewDock Rating Column with ComboBox Delegate

This PR introduces a customizable **"Rating"** column to the ViewDock tool's structure table, enabling interactive rating of docking results. Ratings are implemented using a `QComboBox` delegate.

### Key Changes
- **New `RatingDelegate` class**:
  - Provides a `QComboBox` editor for rating values.
  - Ensures proper synchronization between UI selections and `AtomicStructure.viewdockx_data`.
  - Maintains consistent visual rendering of combo boxes in all states (selected, unselected, editing).
- **Editable "Rating" column added to `ItemTable`**:
  - Initialized with default values from `viewdockx_data`.
  - Editable via combo box (values: 1, 2, 3).

![Screenshot 2025-04-05 at 1 36 10 PM](https://github.com/user-attachments/assets/e4c15fd6-43bf-4965-bdde-8350b1ffabfb)

