### PR TITLE
feature/viewdock/hbonds

### DIFF
--- a/src/bundles/viewdock/src/tool.py
+++ b/src/bundles/viewdock/src/tool.py
@@ -24,7 +24,8 @@ from chimerax.core.tools import ToolInstance
 from chimerax.ui.widgets import ItemTable
 from chimerax.core.commands import run
 from chimerax.core.models import REMOVE_MODELS
-from Qt.QtWidgets import QStyledItemDelegate, QComboBox, QAbstractItemView, QVBoxLayout, QStyle, QStyleOptionComboBox
+from Qt.QtWidgets import (QStyledItemDelegate, QComboBox, QAbstractItemView, QVBoxLayout, QStyle, QStyleOptionComboBox,
+                          QHBoxLayout, QPushButton)
 from Qt.QtCore import Qt
 
 class ViewDockTool(ToolInstance):
@@ -44,11 +45,31 @@ class ViewDockTool(ToolInstance):
         self.tool_window.ui_area.setLayout(self.main_v_layout)
 
         self.structures = structures
+
+        self.top_buttons_layout = QHBoxLayout()
+        self.top_buttons_setup()
+        self.main_v_layout.addLayout(self.top_buttons_layout)
+
+
         self.struct_table = ItemTable(session=self.session)
         self.table_setup()
         self.handlers = []
         self.add_handlers()
         self.tool_window.manage('side')
+
+    def top_buttons_setup(self):
+        """
+        Create the top buttons for the tool (HBonds).
+        """
+        self.hbonds_button = QPushButton("HBonds")
+        self.hbonds_button.clicked.connect(self.hbonds_callback)
+        self.top_buttons_layout.addWidget(self.hbonds_button)
+
+    def hbonds_callback(self):
+        """
+        Callback function for the HBonds button click.
+        """
+        pass
 
     def table_setup(self):
         """

--- a/src/bundles/viewdock/src/tool.py
+++ b/src/bundles/viewdock/src/tool.py
@@ -84,7 +84,7 @@ class ViewDockTool(ToolInstance):
 
         # Create a QDialog to act as the popup
         dialog = QDialog(self.tool_window.ui_area)
-        dialog.setWindowTitle("HBonds")
+        dialog.setWindowTitle(f"{self.display_name} HBonds")
 
         # Set the layout for the dialog
         layout = QVBoxLayout(dialog)

--- a/src/bundles/viewdock/src/tool.py
+++ b/src/bundles/viewdock/src/tool.py
@@ -25,7 +25,7 @@ from chimerax.ui.widgets import ItemTable
 from chimerax.core.commands import run
 from chimerax.core.models import REMOVE_MODELS
 from Qt.QtWidgets import (QStyledItemDelegate, QComboBox, QAbstractItemView, QVBoxLayout, QStyle, QStyleOptionComboBox,
-                          QHBoxLayout, QPushButton)
+                          QHBoxLayout, QPushButton, QDialog)
 from Qt.QtCore import Qt
 
 class ViewDockTool(ToolInstance):
@@ -69,7 +69,32 @@ class ViewDockTool(ToolInstance):
         """
         Callback function for the HBonds button click.
         """
-        pass
+        from chimerax.core.commands import concise_model_spec, run
+        from chimerax.atomic import AtomicStructure
+        mine = concise_model_spec(self.session, self.structures)
+        all = self.session.models.list(type=AtomicStructure)
+        others = concise_model_spec(self.session,
+                                    set(all) - set(self.structures))
+        from chimerax.hbonds.gui import HBondsGUI
+        """
+            Callback function for the HBonds button click.
+            """
+        # Create the HBondsGUI instance
+        hbonds_gui = HBondsGUI(self.session, restrict=others)
+
+        # Create a QDialog to act as the popup
+        dialog = QDialog(self.tool_window.ui_area)
+        dialog.setWindowTitle("HBonds")
+
+        # Set the layout for the dialog
+        layout = QVBoxLayout(dialog)
+        dialog.setLayout(layout)
+
+        # Add the HBondsGUI widget to the dialog's layout
+        layout.addWidget(hbonds_gui)
+
+        # Show the dialog
+        dialog.exec()
 
     def table_setup(self):
         """

--- a/src/bundles/viewdock/src/tool.py
+++ b/src/bundles/viewdock/src/tool.py
@@ -78,15 +78,11 @@ class ViewDockTool(ToolInstance):
 
         The analysis is restricted to the current set of binding analysis structures against any other AtomicStructures.
         """
-
-        # Create the HBondsGUI instance
         hbonds_gui = HBondsGUI(self.session, show_model_restrict=False, show_bond_restrict=False)
 
         # Create a QDialog to act as the popup
         dialog = QDialog(self.tool_window.ui_area)
         dialog.setWindowTitle(f"{self.display_name} HBonds")
-
-        # Set the layout for the dialog
         layout = QVBoxLayout(dialog)
         dialog.setLayout(layout)
 


### PR DESCRIPTION
## Add HBonds Analysis to ViewDock Tool

### Summary

This PR introduces a new **HBonds** button to the `ViewDock` tool, allowing users to run hydrogen bond analysis between binding structures and the rest of the session's atomic models. The analysis is configured via a GUI dialog using ChimeraX's `HBondsGUI`.

### Features

- **HBonds Button**:
  - Added to the top of the `ViewDock` layout.
  - Opens a `QDialog` containing the `HBondsGUI` for analysis configuration.

- **Hydrogen Bond Dialog**:
  - Simplified interface: disables model and bond restriction selectors.
  - Integrates `Ok` and `Cancel` buttons via `QDialogButtonBox`.
  - On "Ok", constructs and runs a `hbonds` command:
    - Restricts analysis to the selected binding structures vs. all other `AtomicStructure`s in the session.

<img width="1440" alt="Screenshot 2025-04-09 at 10 56 19 AM" src="https://github.com/user-attachments/assets/ecdc7928-d0d1-4648-acc5-680b7e5827e6" />
