### PR TITLE
feature/viewdock/clashes

### DIFF
--- a/src/bundles/viewdock/src/tool.py
+++ b/src/bundles/viewdock/src/tool.py
@@ -23,6 +23,7 @@
 from chimerax.atomic import AtomicStructure
 from chimerax.core.tools import ToolInstance
 from chimerax.hbonds.gui import HBondsGUI
+from chimerax.clashes.gui import ClashesGUI
 from chimerax.ui.widgets import ItemTable
 from chimerax.core.commands import run, concise_model_spec
 from chimerax.core.models import REMOVE_MODELS
@@ -62,48 +63,56 @@ class ViewDockTool(ToolInstance):
 
     def top_buttons_setup(self):
         """
-        Create the top buttons for the tool (HBonds).
+        Create the top buttons for the tool (HBonds and Clashes).
         """
         self.hbonds_button = QPushButton("HBonds")
-        self.hbonds_button.clicked.connect(self.hbonds_callback)
+        self.hbonds_button.clicked.connect(
+            lambda: self.popup_callback(
+                HBondsGUI, "HBonds", show_model_restrict=False, show_bond_restrict=False
+            )
+        )
         self.top_buttons_layout.addWidget(self.hbonds_button, alignment=Qt.AlignCenter)
 
-    def hbonds_callback(self):
-        """
-        Callback function for the HBonds button click.
+        self.clashes_button = QPushButton("Clashes")
+        self.clashes_button.clicked.connect(
+            lambda: self.popup_callback(ClashesGUI, "Clashes", has_apply_button=False, show_restrict=False)
+        )
+        self.top_buttons_layout.addWidget(self.clashes_button, alignment=Qt.AlignCenter)
 
-        This method creates a popup dialog containing the HBondsGUI widget for configuring hydrogen bond analysis.
-        The dialog includes "Ok" and "Cancel" buttons. When "Ok" is clicked, the method retrieves the command
-        from the HBondsGUI, constructs a command string to perform hydrogen bond analysis, and executes it.
-
-        The analysis is restricted to the current set of binding analysis structures against any other AtomicStructures.
+    def popup_callback(self, gui_class, popup_name, **kwargs):
         """
-        hbonds_gui = HBondsGUI(self.session, show_model_restrict=False, show_bond_restrict=False)
+        Generalized callback function for creating a popup dialog with a specified GUI widget.
+
+        Args:
+            gui_class: The GUI class to instantiate (e.g., HBondsGUI, ClashesGUI).
+            popup_name: The command name to execute (e.g., "hbonds", "clashes").
+            **kwargs: Additional keyword arguments to pass to the GUI class constructor.
+        """
+        gui_instance = gui_class(self.session, **kwargs)
 
         # Create a QDialog to act as the popup
         dialog = QDialog(self.tool_window.ui_area)
-        dialog.setWindowTitle(f"{self.display_name} HBonds")
+        dialog.setWindowTitle(f"{self.display_name} {popup_name.capitalize()}")
         layout = QVBoxLayout(dialog)
         dialog.setLayout(layout)
 
-        # Add the HBondsGUI widget to the dialog's layout
-        layout.addWidget(hbonds_gui)
+        # Add the GUI widget to the dialog's layout
+        layout.addWidget(gui_instance)
 
         # Add Ok/Cancel buttons
         button_box = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
         layout.addWidget(button_box)
 
-        # Connect the Ok button to call hbonds_gui.get_command()
+        # Connect the Ok button to call gui_instance.get_command()
         def on_ok():
-            command = hbonds_gui.get_command()
+            command = gui_instance.get_command()
             # Binding analysis structures
             mine = concise_model_spec(self.session, self.structures)
             all_structures = self.session.models.list(type=AtomicStructure)
             # All structures that are AtomicStructures but not in the binding analysis structures
             others = concise_model_spec(self.session, set(all_structures) - set(self.structures))
 
-            # command[0] = command name ('hbonds'), command[1] = model selection (omit and force our binding structures),
-            # command[2] = all other keyword arguments from hbonds gui
+            # command[0] = command name, command[1] = model selection, command[2] = other arguments
             run(self.session, f"{command[0]} {mine} restrict {others} {command[2]}")
             dialog.accept()
 

--- a/src/bundles/viewdock/src/tool.py
+++ b/src/bundles/viewdock/src/tool.py
@@ -28,7 +28,7 @@ from chimerax.ui.widgets import ItemTable
 from chimerax.core.commands import run, concise_model_spec
 from chimerax.core.models import REMOVE_MODELS
 from Qt.QtWidgets import (QStyledItemDelegate, QComboBox, QAbstractItemView, QVBoxLayout, QStyle, QStyleOptionComboBox,
-                          QHBoxLayout, QPushButton, QDialog, QDialogButtonBox)
+                          QHBoxLayout, QPushButton, QDialog, QDialogButtonBox, QSizePolicy)
 from Qt.QtCore import Qt
 
 
@@ -71,13 +71,14 @@ class ViewDockTool(ToolInstance):
                 HBondsGUI, "HBonds", show_model_restrict=False, show_bond_restrict=False
             )
         )
-        self.top_buttons_layout.addWidget(self.hbonds_button, alignment=Qt.AlignCenter)
+        self.top_buttons_layout.addWidget(self.hbonds_button)
 
         self.clashes_button = QPushButton("Clashes")
         self.clashes_button.clicked.connect(
             lambda: self.popup_callback(ClashesGUI, "Clashes", has_apply_button=False, show_restrict=False)
         )
-        self.top_buttons_layout.addWidget(self.clashes_button, alignment=Qt.AlignCenter)
+        self.top_buttons_layout.addWidget(self.clashes_button)
+        self.top_buttons_layout.setAlignment(Qt.AlignLeft)
 
     def popup_callback(self, gui_class, popup_name, **kwargs):
         """


### PR DESCRIPTION
## Add Clashes Button to ViewDock Tool

### Description

This PR introduces a new "Clashes" analysis option in the ViewDock tool and refactors the popup logic to support dynamic GUI dialog creation.

### Features

- **Clashes Button**  
  - Added a "Clashes" button to the top layout next to "HBonds".  
  - Launches the `ClashesGUI` in a popup.  
  - Disables model restriction selection and forces clashes between all binding structures and all other `AtomicStructure` models.

- **Generalized Popup Logic**  
  - Introduced `popup_callback`, a reusable method for creating popup dialogs from arbitrary GUI widgets with keyword arguments.  
  - Replaces the hardcoded HBonds dialog logic.

- **UI Refinement**  
  - Aligned the top button `QHBoxLayout` to `Qt.AlignLeft` to reduce blank space.

![Screenshot 2025-04-10 at 6 15 10 PM](https://github.com/user-attachments/assets/5630a226-dd19-4736-9727-65fd0a955ad0)