### PR TITLE
Feature/viewdock/model description

### DIFF
--- a/src/bundles/viewdock/src/tool.py
+++ b/src/bundles/viewdock/src/tool.py
@@ -28,7 +28,7 @@ from chimerax.ui.widgets import ItemTable
 from chimerax.core.commands import run, concise_model_spec
 from chimerax.core.models import REMOVE_MODELS, MODEL_DISPLAY_CHANGED
 from Qt.QtWidgets import (QStyledItemDelegate, QComboBox, QAbstractItemView, QVBoxLayout, QStyle, QStyleOptionComboBox,
-                          QHBoxLayout, QPushButton, QDialog, QDialogButtonBox, QSizePolicy)
+                          QHBoxLayout, QPushButton, QDialog, QDialogButtonBox, QGroupBox)
 from Qt.QtCore import Qt
 
 
@@ -57,6 +57,10 @@ class ViewDockTool(ToolInstance):
 
         self.struct_table = ItemTable(session=self.session)
         self.table_setup()
+
+        self.description_group = QGroupBox()
+        self.description_box_setup()
+
         self.handlers = []
         self.add_handlers()
         self.tool_window.manage('side')
@@ -176,6 +180,33 @@ class ViewDockTool(ToolInstance):
 
         # Add the table to the layout
         self.main_v_layout.addWidget(self.struct_table)
+
+    def description_box_setup(self):
+        """
+        Build the description box at the bottom of the tool which displays all the docking attribute information
+        for a selected docking model.
+        """
+
+        # Create a group box for the description box
+        description_layout = QVBoxLayout()
+        self.description_group.setLayout(description_layout)
+
+        self.struct_table.selection_changed.connect(
+            lambda newly_selected, newly_deselected: self.update_model_description(newly_selected)
+        )
+
+        # Add the group box to the main layout
+        self.main_v_layout.addWidget(self.description_group)
+
+    def update_model_description(self, newly_selected):
+        """
+        Update the description box with the selected structure's data. If more then one structure is newly selected only
+        the first one will be displayed.
+
+        Args:
+            newly_selected (list): The newly selected structure(s) in the ItemTable.
+        """
+        pass
 
     def add_handlers(self):
         """

--- a/src/bundles/viewdock/src/tool.py
+++ b/src/bundles/viewdock/src/tool.py
@@ -239,6 +239,22 @@ class ViewDockTool(ToolInstance):
         rows_per_column = (total_attributes + 1) // 2  # Divide attributes evenly over two columns
 
         for index, (key, value) in enumerate(attributes):
+            # Use the column's data_fetch to get the value for attributes appearing in the table
+            column = next((col for col in self.struct_table.columns if col.title == key), None)
+            if column and column.data_fetch:
+                # Fetch the value using the column's data_fetch
+                if callable(column.data_fetch):
+                    value = column.data_fetch(docking_structure)
+                else:
+                    # If data_fetch wasn't initialized as a callable, assume data_fetch is a string representing an
+                    # attribute path
+                    value = docking_structure
+                    for attr in column.data_fetch.split('.'):
+                        # Loop through nested attributes
+                        value = getattr(value, attr, None)
+                        if value is None:
+                            break
+
             row = index % rows_per_column
             col = (index // rows_per_column) * 2  # Multiply by 2 to account for key-value pairs
 

--- a/src/bundles/viewdock/src/tool.py
+++ b/src/bundles/viewdock/src/tool.py
@@ -29,6 +29,7 @@ from chimerax.core.commands import run, concise_model_spec
 from chimerax.core.models import REMOVE_MODELS, MODEL_DISPLAY_CHANGED
 from Qt.QtWidgets import (QStyledItemDelegate, QComboBox, QAbstractItemView, QVBoxLayout, QStyle, QStyleOptionComboBox,
                           QHBoxLayout, QPushButton, QDialog, QDialogButtonBox, QGroupBox)
+from Qt.QtGui import QFont
 from Qt.QtCore import Qt
 
 
@@ -191,6 +192,14 @@ class ViewDockTool(ToolInstance):
         description_layout = QVBoxLayout()
         self.description_group.setLayout(description_layout)
 
+        # Set the title alignment to center
+        self.description_group.setAlignment(Qt.AlignCenter)
+
+        # Customize the font for the title
+        title_font = QFont()
+        title_font.setPointSize(16)  # Set font size
+        self.description_group.setFont(title_font)
+
         self.struct_table.selection_changed.connect(
             lambda newly_selected, newly_deselected: self.update_model_description(newly_selected)
         )
@@ -206,7 +215,10 @@ class ViewDockTool(ToolInstance):
         Args:
             newly_selected (list): The newly selected structure(s) in the ItemTable.
         """
-        pass
+        if not newly_selected:
+            return
+        docking_structure = newly_selected[0]
+        self.description_group.setTitle(f"ChimeraX Model {docking_structure.atomspec}")
 
     def add_handlers(self):
         """

--- a/src/bundles/viewdock/src/tool.py
+++ b/src/bundles/viewdock/src/tool.py
@@ -206,6 +206,8 @@ class ViewDockTool(ToolInstance):
 
         # Add the group box to the main layout
         self.main_v_layout.addWidget(self.description_group)
+        # Select the first structure in the table to display its data in the description box
+        self.struct_table.selected = [self.structures[0]]
 
     def update_model_description(self, newly_selected):
         """


### PR DESCRIPTION
## feat(viewdock): Add docking model description display box to tool

This PR adds a new description section to the ViewDock tool that displays detailed attribute information for the selected docking model.

Note: The description box currently mirrors the table information, but will be more relevant once shown columns are configurable and the table does not display all docking attributes.

### ✨ Features
- Introduced a `QGroupBox` UI element to house model descriptions.
- Automatically updates the description box when a different docking model is selected.
- Displays docking attributes (e.g., score, RMSD) as key-value pairs in a two-column layout.
- On tool open, automatically highlights the first structure and initializes the description box.

### 🛠️ Implementation Notes
- `description_box_setup()` initializes and styles the layout, and connects the table selection change signal.
- `update_model_description()` populates the description layout with docking attributes from the selected model.
- Docking attributes that are also in the table use the corresponding column's `data_fetch`—a callable defined per column to extract and format the value out of the model.

![Screenshot 2025-04-25 at 5 28 03 PM](https://github.com/user-attachments/assets/687972fe-7ee2-4e9d-bf4e-e16e314c1134)