### PR TITLE
feature/viewdock/customize-table

### DIFF
--- a/src/bundles/viewdock/src/tool.py
+++ b/src/bundles/viewdock/src/tool.py
@@ -163,6 +163,13 @@ class ViewDockTool(ToolInstance):
         the set, the cell will be empty.
         """
 
+        table_group = QGroupBox()
+        table_group_layout = QVBoxLayout()
+
+        table_group_layout.addWidget(self.struct_table)
+        table_group_layout.addWidget(self.col_display_widget)
+        table_group.setLayout(table_group_layout)
+
         # Fixed columns. Generic based on ChimeraX model attributes.
         self.display_col = self.struct_table.add_column('Show', lambda s: s.display, data_set=self.set_visibility, format=ItemTable.COL_FORMAT_BOOLEAN)
         self.struct_table.add_column('ID', lambda s: s.id_string)
@@ -192,11 +199,8 @@ class ViewDockTool(ToolInstance):
         self.struct_table.data = self.structures
         self.struct_table.launch()
 
-        # Add the table to the layout
-        self.main_v_layout.addWidget(self.struct_table)
-
-        # Add the column display settings widget to the layout
-        self.main_v_layout.addWidget(self.col_display_widget)
+        # Add the table group to the layout
+        self.main_v_layout.addWidget(table_group)
 
     def description_box_setup(self):
         """

--- a/src/bundles/viewdock/src/tool.py
+++ b/src/bundles/viewdock/src/tool.py
@@ -57,9 +57,7 @@ class ViewDockTool(ToolInstance):
         self.top_buttons_setup()
         self.main_v_layout.addLayout(self.top_buttons_layout)
 
-        self.table_menu = QMenu()
         self.settings = ViewDockSettings(self.session, tool_name)
-        self.tool_window.fill_context_menu = self.fill_context_menu
 
         self.col_display_widget = QWidget()
         self.struct_table = ItemTable(session=self.session, column_control_info=(
@@ -73,12 +71,6 @@ class ViewDockTool(ToolInstance):
         self.handlers = []
         self.add_handlers()
         self.tool_window.manage('side')
-
-    def fill_context_menu(self, menu, x, y):
-        """
-        Fill the context menu with options to show/hide structures and set ratings.
-        """
-        menu.addMenu(self.table_menu)
 
     def top_buttons_setup(self):
         """

--- a/src/bundles/viewdock/src/tool.py
+++ b/src/bundles/viewdock/src/tool.py
@@ -119,7 +119,7 @@ class ViewDockTool(ToolInstance):
         Generalized callback function for creating a popup dialog using a specified GUI widget class. This callback
         can be connected to buttons that are supposed to open a dialog for a specific task
         (e.g., HBonds, Clashes...). The GUI Widget class must have a .get_command() implementation that returns a cl
-        command that will be ran when the OK button is clicked in the dialog.
+        command that will be run when the OK button is clicked in the dialog.
 
         Args:
             gui_class: The GUI class to instantiate (e.g., HBondsGUI, ClashesGUI). The class is automatically passed

--- a/src/bundles/viewdock/src/tool.py
+++ b/src/bundles/viewdock/src/tool.py
@@ -31,8 +31,7 @@ from chimerax.ui.widgets import ItemTable
 from chimerax.core.commands import run, concise_model_spec
 from chimerax.core.models import REMOVE_MODELS, MODEL_DISPLAY_CHANGED
 from Qt.QtWidgets import (QStyledItemDelegate, QComboBox, QAbstractItemView, QVBoxLayout, QStyle, QStyleOptionComboBox,
-                          QHBoxLayout, QPushButton, QDialog, QDialogButtonBox, QGroupBox, QGridLayout, QLabel, QWidget,
-                          QSizePolicy)
+                          QHBoxLayout, QPushButton, QDialog, QDialogButtonBox, QGroupBox, QGridLayout, QLabel, QWidget,)
 from Qt.QtGui import QFont
 from Qt.QtCore import Qt
 
@@ -113,10 +112,6 @@ class ViewDockTool(ToolInstance):
         )
         self.top_buttons_layout.addWidget(self.clashes_button)
 
-        self.settings_button = QPushButton("Settings")
-        self.settings_button.clicked.connect(lambda: self.settings_dialog())
-        self.top_buttons_layout.addWidget(self.settings_button)
-
         self.top_buttons_layout.setAlignment(Qt.AlignLeft)
 
     def popup_callback(self, gui_class, popup_name, **kwargs):
@@ -166,32 +161,6 @@ class ViewDockTool(ToolInstance):
         button_box.rejected.connect(dialog.reject)
 
         # Show the dialog
-        dialog.exec()
-
-    def settings_dialog(self):
-        """
-        Create a settings dialog for the ViewDock tool. This dialog allows the user to customize settings related to
-        """
-
-        # Create a QDialog to act as the popup
-        dialog = QDialog(self.tool_window.ui_area)
-        dialog.setWindowTitle(f"{self.display_name} Settings")
-        layout = QVBoxLayout(dialog)
-        dialog.setLayout(layout)
-
-        settings_widget = ViewDockSettingsWidget(self.session, self.col_display_widget, self.structures, self.struct_table)
-        layout.addWidget(settings_widget)
-
-        button_box = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
-        layout.addWidget(button_box)
-
-        def ok():
-            # self.settings.save()
-            dialog.accept()
-
-        button_box.accepted.connect(dialog.accept)
-        button_box.rejected.connect(dialog.reject)
-
         dialog.exec()
 
     def table_setup(self):
@@ -525,36 +494,3 @@ class RatingDelegate(QStyledItemDelegate):
 class ViewDockSettings(Settings):
 
     EXPLICIT_SAVE = {ItemTable.DEFAULT_SETTINGS_ATTR: {}}
-
-
-class ViewDockSettingsWidget(QWidget):
-    """
-    A settings widget the ViewDock tool.
-    """
-
-    def __init__(self, session, col_display_widget, structures, table):
-        """
-        Initialize the settings widget.
-
-        Args:
-            structures: List of docking structures.
-            table: The ItemTable associated with the ViewDock tool.
-        """
-        super().__init__()
-        self.structures = structures
-        self.table = table
-
-        # Main layout
-        layout = QVBoxLayout(self)
-
-        # Create a group box for the column display widget
-        col_disp_box = QGroupBox("Show Columns:")
-        col_disp_layout = QVBoxLayout()
-        col_disp_box.setLayout(col_disp_layout)
-
-        col_disp_layout.addWidget(col_display_widget)
-
-        layout.addWidget(col_disp_box)
-
-        # Add the layout to the widget
-        self.setLayout(layout)

--- a/src/bundles/viewdock/src/tool.py
+++ b/src/bundles/viewdock/src/tool.py
@@ -169,6 +169,10 @@ class ViewDockTool(ToolInstance):
         dialog.exec()
 
     def settings_dialog(self):
+        """
+        Create a settings dialog for the ViewDock tool. This dialog allows the user to customize settings related to
+        """
+
         # Create a QDialog to act as the popup
         dialog = QDialog(self.tool_window.ui_area)
         dialog.setWindowTitle(f"{self.display_name} Settings")
@@ -182,10 +186,10 @@ class ViewDockTool(ToolInstance):
         layout.addWidget(button_box)
 
         def ok():
-            self.settings.save()
+            # self.settings.save()
             dialog.accept()
 
-        button_box.accepted.connect(ok)
+        button_box.accepted.connect(dialog.accept)
         button_box.rejected.connect(dialog.reject)
 
         dialog.exec()
@@ -229,6 +233,9 @@ class ViewDockTool(ToolInstance):
 
         # Add the table to the layout
         self.main_v_layout.addWidget(self.struct_table)
+
+        # Add the column display settings widget to the layout
+        self.main_v_layout.addWidget(self.col_display_widget)
 
     def description_box_setup(self):
         """

--- a/src/bundles/viewdock/src/tool.py
+++ b/src/bundles/viewdock/src/tool.py
@@ -119,18 +119,17 @@ class ViewDockTool(ToolInstance):
 
         self.top_buttons_layout.setAlignment(Qt.AlignLeft)
 
-    def popup_callback(self, gui_class, popup_name, on_ok=None, **kwargs):
+    def popup_callback(self, gui_class, popup_name, **kwargs):
         """
         Generalized callback function for creating a popup dialog using a specified GUI widget class. This callback
         can be connected to buttons that are supposed to open a dialog for a specific task
-        (e.g., HBonds, Clashes, Settings...).
+        (e.g., HBonds, Clashes...). The GUI Widget class must have a .get_command() implementation that returns a cl
+        command that will be ran when the OK button is clicked in the dialog.
 
         Args:
             gui_class: The GUI class to instantiate (e.g., HBondsGUI, ClashesGUI). The class is automatically passed
                 the session in its constructor.
             popup_name: The command name to execute (e.g., "hbonds", "clashes").
-            on_ok: Optional callback function to execute when the Ok button is clicked. If not provided, a default
-                function will be used that retrieves the command from the GUI using GUI.get_command() and runs it.
             **kwargs: Additional keyword arguments to pass to the GUI class constructor. Session is passed to all GUI
                 class constructors automatically and should not be specified in this list
         """
@@ -151,19 +150,16 @@ class ViewDockTool(ToolInstance):
 
         # Connect the Ok button to call gui_instance.get_command()
         def ok_cb():
-            if on_ok and callable(on_ok):
-                on_ok()
-            else:
-                # Default behavior for chimerax.ui.widgets
-                command = gui_instance.get_command()
-                # Binding analysis structures
-                mine = concise_model_spec(self.session, self.structures)
-                all_structures = self.session.models.list(type=AtomicStructure)
-                # All structures that are AtomicStructures but not in the binding analysis structures
-                others = concise_model_spec(self.session, set(all_structures) - set(self.structures))
+            # Default behavior for chimerax.ui.widgets
+            command = gui_instance.get_command()
+            # Binding analysis structures
+            mine = concise_model_spec(self.session, self.structures)
+            all_structures = self.session.models.list(type=AtomicStructure)
+            # All structures that are AtomicStructures but not in the binding analysis structures
+            others = concise_model_spec(self.session, set(all_structures) - set(self.structures))
 
-                # command[0] = command name, command[1] = model selection, command[2] = other arguments
-                run(self.session, f"{command[0]} {mine} restrict {others} {command[2]}")
+            # command[0] = command name, command[1] = model selection, command[2] = other arguments
+            run(self.session, f"{command[0]} {mine} restrict {others} {command[2]}")
             dialog.accept()
 
         button_box.accepted.connect(ok_cb)

--- a/src/bundles/viewdock/src/tool.py
+++ b/src/bundles/viewdock/src/tool.py
@@ -32,7 +32,7 @@ from chimerax.core.commands import run, concise_model_spec
 from chimerax.core.models import REMOVE_MODELS, MODEL_DISPLAY_CHANGED
 from Qt.QtWidgets import (QStyledItemDelegate, QComboBox, QAbstractItemView, QVBoxLayout, QStyle, QStyleOptionComboBox,
                           QHBoxLayout, QPushButton, QDialog, QDialogButtonBox, QGroupBox, QGridLayout, QLabel, QWidget,
-                          QListWidget, QListWidgetItem)
+                          QSizePolicy)
 from Qt.QtGui import QFont
 from Qt.QtCore import Qt
 
@@ -539,7 +539,15 @@ class ViewDockSettingsWidget(QWidget):
 
         # Main layout
         layout = QVBoxLayout(self)
-        layout.addWidget(col_display_widget)
+
+        # Create a group box for the column display widget
+        col_disp_box = QGroupBox("Show Columns:")
+        col_disp_layout = QVBoxLayout()
+        col_disp_box.setLayout(col_disp_layout)
+
+        col_disp_layout.addWidget(col_display_widget)
+
+        layout.addWidget(col_disp_box)
 
         # Add the layout to the widget
         self.setLayout(layout)


### PR DESCRIPTION
## Summary

This PR introduces a column display settings widget beneath the structure table in the ViewDock tool. Users can toggle which columns are shown, and their preferences persist across tool instances.

## Implementation Details

- Introduced `ViewDockSettings`, a subclass of `chimerax.core.settings.Settings`, to manage persistent storage of column visibility.
- The `ItemTable` is now initialized with the `column_control_info` parameter to link it with the display widget and settings object.

## Additional Changes

- Clarified docstring for the `popup_callback()` method, including argument expectations and behavior.

![Screenshot 2025-05-10 at 11 18 43 PM](https://github.com/user-attachments/assets/d06ae95a-492d-4f2c-9467-bc591e8a4f7f)
![Screenshot 2025-05-10 at 11 19 33 PM](https://github.com/user-attachments/assets/f1b66b91-cb39-493b-a4d3-67ae0fdf2455)
![Screenshot 2025-05-10 at 11 19 50 PM](https://github.com/user-attachments/assets/9279e300-4f57-4d8d-986e-db11b2ca1cad)
