### PR TITLE
refactor/viewdock/docking-data-attr

### DIFF
--- a/src/bundles/viewdock/src/__init__.py
+++ b/src/bundles/viewdock/src/__init__.py
@@ -64,7 +64,7 @@ class _MyAPI(BundleAPI):
                 all_models = sum([m.all_models() for m in models], start=[])
                 if show_tool and session.ui.is_gui and len(all_models) > 1:
                     for m in all_models:
-                        if hasattr(m, 'viewdockx_data'):
+                        if hasattr(m, 'viewdock_data'):
                             show_dock = True
                             break
                     else:

--- a/src/bundles/viewdock/src/io.py
+++ b/src/bundles/viewdock/src/io.py
@@ -181,11 +181,11 @@ class Mol2Parser:
             # Create structure
             s = SC(self.session, auto_style=self.auto_style)
             s.name = self._molecule.mol_name
-            SC.register_attr(self.session, "viewdockx_data", "ViewDockX")
+            SC.register_attr(self.session, "viewdock_data", "ViewDock")
             from chimerax.atomic import Atom
-            Atom.register_attr(self.session, "charge", "ViewDockX", attr_type=float)
-            Atom.register_attr(self.session, "mol2_type", "ViewDockX", attr_type=str)
-            s.viewdockx_data = self._data
+            Atom.register_attr(self.session, "charge", "ViewDock", attr_type=float)
+            Atom.register_attr(self.session, "mol2_type", "ViewDock", attr_type=str)
+            s.viewdock_data = self._data
             if self._molecule.charge_type:
                 s.charge_model = self._molecule.charge_type
             if self._molecule.mol_type:
@@ -496,7 +496,7 @@ def open_swissdock(session, stream, file_name, auto_style, atomic):
     is_ligands = True
     used_chains = set()
     cur_in_chain = cur_out_chain = cur_res_num = None
-    viewdockx_data = {}
+    viewdock_data = {}
     models = []
     status = ""
     from chimerax.pdb import open_pdb
@@ -530,23 +530,23 @@ def open_swissdock(session, stream, file_name, auto_style, atomic):
                 ligs, status = open_pdb(session, out_f.name, file_name=file_name, auto_style=auto_style,
                         atomic=atomic)
                 for lig in ligs:
-                    lig.viewdockx_data = viewdockx_data
+                    lig.viewdock_data = viewdock_data
                     models.append(lig)
                 os.unlink(out_f.name)
                 out_f = tempfile.NamedTemporaryFile(mode='w', encoding='utf-8', suffix=".pdb", delete=False)
-                viewdockx_data = {}
+                viewdock_data = {}
         elif line.startswith("REMARK"):
             if line.count(': ') != 1:
                 is_ligands = False
             else:
                 k,v = line[7:].strip().split(': ')
-                viewdockx_data[_wordize(k)] = _value(v)
+                viewdock_data[_wordize(k)] = _value(v)
             # these "REMARK"s are all badly formatted, prevent ChimeraX from complaining
             line = None
         if line is not None:
             print(line, file=out_f)
     if is_ligands and models:
-        models[0].__class__.register_attr(session, "viewdockx_data", "ViewDockX")
+        models[0].__class__.register_attr(session, "viewdock_data", "ViewDock")
     out_f.close()
     if not is_ligands:
         models, status = open_pdb(session, out_f.name,

--- a/src/bundles/viewdock/src/io.py
+++ b/src/bundles/viewdock/src/io.py
@@ -170,7 +170,22 @@ class Mol2Parser:
         self._comments = []
 
     def _make_structure(self):
-        """Build ChimeraX structure and reset structure data cache"""
+        """
+        Build ChimeraX structure and reset structure data cache
+
+        Note:
+            Old ViewDockX (this bundl's predecessor) sessions have already registered a docking data attribute to structures
+            called "viewdockx_data". When this function is called with an old ViewDockX session, it will still register a
+            new docking data attribute called "viewdock_data". This bundle will NOT support reference to the old
+            "viewdockx_data" attribute.
+
+            Old ViewDockX sessions also registered the "charge" and "mol2_type" attributes to atoms. This function will
+            not re-register these attributes due to the workings of chimerax.core.attributes.register_attr. However,
+            since these attrs are registered with the same name and data types in ViewDock (this bundle), they can still
+            be accessed normally. In this scenario, the only difference is the attributes will still appear to be
+            registered by ViewDockX (this bundl's predecessor).
+        """
+
         try:
             if self._molecule is None:
                 return
@@ -486,6 +501,13 @@ def _value(s):
             return s
 
 def open_swissdock(session, stream, file_name, auto_style, atomic):
+    """
+    Note:
+        Old ViewDockX (Previous tool version) sessions have already registered a docking data attribute to structures
+        called "viewdockx_data". When this function is called with an old ViewDockX session, it will still register a
+        new docking data attribute called "viewdock_data". This bundle will NOT support reference to the old
+        "viewdockx_data" attribute.
+    """
     from chimerax.atomic import next_chain_id
     import tempfile
     import os

--- a/src/bundles/viewdock/src/pdbqt.py
+++ b/src/bundles/viewdock/src/pdbqt.py
@@ -62,6 +62,13 @@ def _open_pdbqt(session, path, file_name, auto_style, atomic, encoding):
 
 
 def _extract_metadata(session, f, structures):
+    """
+    Note:
+        Old ViewDockX (this bundl's predecessor) sessions have already registered a docking data attribute to structures
+        called "viewdockx_data". When this function is called with an old ViewDockX session, it will still register a
+        new docking data attribute called "viewdock_data". This bundle will NOT support reference to the old
+        "viewdockx_data" attribute.
+    """
     in_model = False
     model_index = -1
     vina_values = {}

--- a/src/bundles/viewdock/src/pdbqt.py
+++ b/src/bundles/viewdock/src/pdbqt.py
@@ -80,7 +80,7 @@ def _extract_metadata(session, f, structures):
         elif record_type == "ENDMDL":
             if vina_values:
                 from chimerax.atomic import Structure as SC
-                SC.register_attr(session, "viewdockx_data", "ViewDockX")
-                structures[model_index].viewdockx_data = vina_values
+                SC.register_attr(session, "viewdock_data", "ViewDock")
+                structures[model_index].viewdock_data = vina_values
                 vina_values = {}
             in_model = False

--- a/src/bundles/viewdock/src/tool.py
+++ b/src/bundles/viewdock/src/tool.py
@@ -160,7 +160,7 @@ class ViewDockTool(ToolInstance):
     def table_setup(self):
         """
         Create the ItemTable for the structures. Add a column for the display with check boxes, a column for the
-        structure ID, a column for the Rating with a custom delegate, and columns for each key in the viewdockx_data
+        structure ID, a column for the Rating with a custom delegate, and columns for each key in the viewdock_data
         attribute of each structure (e.g., Name, Description, Energy Score...). If a structure does not have a key from
         the set, the cell will be empty.
         """
@@ -178,7 +178,7 @@ class ViewDockTool(ToolInstance):
 
         # Custom Rating delegate
         delegate = RatingDelegate(self.struct_table)  # Create the delegate instance
-        self.struct_table.add_column('Rating', lambda s: s.viewdockx_data.get('Rating', 2),
+        self.struct_table.add_column('Rating', lambda s: s.viewdock_data.get('Rating', 2),
                                      data_set = lambda item, value: None,
                                      editable=True)
 
@@ -190,12 +190,12 @@ class ViewDockTool(ToolInstance):
         # multiple selections to edit the rating of a structure.
         self.struct_table.setEditTriggers(QAbstractItemView.EditTrigger.CurrentChanged)
 
-        # Collect all unique keys from viewdockx_data of all structures and add them as columns
+        # Collect all unique keys from viewdock_data of all structures and add them as columns
         viewdockx_keys = set()
         for structure in self.structures:
-            viewdockx_keys.update(structure.viewdockx_data.keys())
+            viewdockx_keys.update(structure.viewdock_data.keys())
         for key in viewdockx_keys:
-            self.struct_table.add_column(key, lambda s, k=key: s.viewdockx_data.get(k, ''))
+            self.struct_table.add_column(key, lambda s, k=key: s.viewdock_data.get(k, ''))
 
         # Set the data for the table and launch it
         self.struct_table.data = self.structures
@@ -260,7 +260,7 @@ class ViewDockTool(ToolInstance):
                 widget.deleteLater()
 
         # Add attributes in a grid layout
-        attributes = list(docking_structure.viewdockx_data.items())
+        attributes = list(docking_structure.viewdock_data.items())
         total_attributes = len(attributes)
         rows_per_column = (total_attributes + 1) // 2  # Divide attributes evenly over two columns
 
@@ -431,7 +431,7 @@ class RatingDelegate(QStyledItemDelegate):
         # Get the structure (chimerax Structure) from the table row.
         structure = self.parent().data[index.row()]
         new_rating = int(editor.currentText())
-        structure.viewdockx_data['Rating'] = new_rating  # Update the rating in the structure's data
+        structure.viewdock_data['Rating'] = new_rating  # Update the rating in the structure's data
 
         model.setData(index, new_rating)  # Optionally, set the value in the model too. This is for Qt completeness
 


### PR DESCRIPTION
## Refactor: Update ViewDock Registered Session Saving Attribute Names

This PR ensures that the **ViewDock** bundle uses its **own uniquely named session attributes**, avoiding confusion or conflicts with the legacy **ViewDockX** bundle.

Previously, ViewDock reused the `viewdockx_data` attribute originally registered as a session-saving attribute on structures by ViewDockX, making it unclear which bundle owned or created the data. This update changes all internal and registered uses of that attribute to `viewdock_data`, clearly marking it as owned by ViewDock. The atom-level attributes `"mol2_type"` and `"charge"` are now also registered under `"ViewDock"` instead of `"ViewDockX"`.

### 🔁 **Backwards Compatibility**  
Sessions created with ViewDockX will still work—for old sessions, ViewDock adds its own docking data attribute while preserving the old one, ensuring both bundles can continue to function independently without interfering with each other’s state. The atom-level attributes remain fully compatible with old sessions. The ViewDock bundle does not re-register them if they exist from ViewDockX, since their names and data types are unchanged, but they function identically in both bundles. Only the source bundle name for registration differs. This helps clarify in new sessions that ViewDock—not ViewDockX—is responsible for handling these attributes when active.

**Note:** If the ViewDockX bundle were, for some reason, to update the data types it registers for the atom-level attributes `"mol2_type"` and `"charge"`, the ViewDock bundle would raise a `chimerax.core.attributes.RegistrationConflict`. The current assumption is that the ViewDockX bundle will either be removed or never updated again.







