### PR TITLE
feature/viewdock/open-file-caption

### DIFF
--- a/src/bundles/viewdock/bundle_info.xml
+++ b/src/bundles/viewdock/bundle_info.xml
@@ -27,7 +27,7 @@ UCSF DOCK output in PDB and mol2 formats are supported.
     <Dependency name="ChimeraX-Mol2" version="~=2.0"/>
     <Dependency name="ChimeraX-UI" version="~=1.0"/>
     <Dependency name="ChimeraX-DataFormats" version="~=1.0"/>
-    <Dependency name="ChimeraX-OpenCommand" version="~=1.0"/>
+    <Dependency name="ChimeraX-OpenCommand" version="~=1.15"/>
   </Dependencies>
 
   <Providers manager="data formats">

--- a/src/bundles/viewdock/src/__init__.py
+++ b/src/bundles/viewdock/src/__init__.py
@@ -96,7 +96,7 @@ def show_docking_file_dialogue(session):
         session.logger.warning("No docking results formats found.")
         return
     from chimerax.open_command import show_open_file_dialog
-    show_open_file_dialog(session, format_names=docking_formats_names)
+    show_open_file_dialog(session, format_names=docking_formats_names, caption="Choose Docking Results File")
 
 
 def open_viewdock_tool(session, structures):


### PR DESCRIPTION
## Feature: Caption in Open Dialog for ViewDock Tool

The `open_command` module (version 1.15) introduces support for setting a caption in the `show_open_file_dialog`. This pull request updates the ViewDock tool to use this feature, providing a caption that informs users they are expected to open a docking results file.

This enhancement improves usability by making the dialog's purpose clearer to users.