### PR TITLE
feature/viewdock/vdx-session-conversion

### DIFF
--- a/src/bundles/core/src/toolshed/__init__.py
+++ b/src/bundles/core/src/toolshed/__init__.py
@@ -770,6 +770,7 @@ class Toolshed:
             "ChimeraX-Scheme-Mgr": "ChimeraX-SchemeMgr",
             "ChimeraX-SEQ-VIEW": "ChimeraX-SeqView",
             "ChimeraX-Std-Commands": "ChimeraX-StdCommands",
+            "ChimeraX-ViewDockX": "ChimeraX-ViewDock"
         }.get(name, name)
         lc_name = name.casefold().replace("_", "-")
         lc_names = [lc_name]

--- a/src/bundles/viewdock/src/__init__.py
+++ b/src/bundles/viewdock/src/__init__.py
@@ -37,7 +37,7 @@ class _MyAPI(BundleAPI):
 
     @staticmethod
     def get_class(name):
-        if name == "ViewDockTool":
+        if name == "ViewDockTool" or name == "TableTool":
             from .tool import ViewDockTool
             return ViewDockTool
         return None

--- a/src/bundles/viewdock/src/tool.py
+++ b/src/bundles/viewdock/src/tool.py
@@ -390,23 +390,21 @@ class ViewDockTool(ToolInstance):
         Restore snapshots for the ViewDock tool and the old ViewDockX tool.
         """
         # ViewDockX snapshots
-        try:
-            if 'vdxtable' in snapshot['_html_state']['name']:
-                if snapshot['version'] != 2:
-                    session.logger.warning(
-                        f"Incompatible ViewDockX snapshot version {snapshot['version']}. "
-                        "Can only convert ViewDockX version 2 tool instances for ViewDock."
-                    )
-                    return None
-                return cls(session, "ViewDock", snapshot['structures'])
-        except:
-            # ViewDock snapshots
-            if snapshot['version'] != 1:
+        if '_html_state' in snapshot and 'vdxtable' in snapshot['_html_state']['name']:
+            if snapshot['version'] != 2:
                 session.logger.warning(
-                    f"Incompatible snapshot version {snapshot['version']} for ViewDock tool. "
-                    "Expected version 1."
+                    f"Incompatible ViewDockX snapshot version {snapshot['version']}. "
+                    "Can only convert ViewDockX version 2 tool instances for ViewDock."
                 )
                 return None
+            return cls(session, "ViewDock", snapshot['structures'])
+        # ViewDock snapshots
+        if snapshot['version'] != 1:
+            session.logger.warning(
+                f"Incompatible snapshot version {snapshot['version']} for ViewDock tool. "
+                "Expected version 1."
+            )
+            return None
 
         return cls(session, snapshot['tool_name'], snapshot['structures'])
 

--- a/src/bundles/viewdock/src/tool.py
+++ b/src/bundles/viewdock/src/tool.py
@@ -51,7 +51,7 @@ class ViewDockTool(ToolInstance):
         self.main_v_layout = QVBoxLayout()
         self.tool_window.ui_area.setLayout(self.main_v_layout)
 
-        self.structures = structures
+        self.structures = self.filter_structures(structures)
 
         self.top_buttons_layout = QHBoxLayout()
         self.top_buttons_setup()
@@ -71,6 +71,22 @@ class ViewDockTool(ToolInstance):
         self.handlers = []
         self.add_handlers()
         self.tool_window.manage('side')
+
+    def filter_structures(self, structures):
+        """
+        Ensure that ViewDockX structures have the viewdock_data attribute that the ViewDock tool expects.
+
+        Args:
+            structures (list): A list of structures.
+
+        Returns:
+            list: Only structures that have the viewdock_data attribute.
+        """
+        for structure in structures:
+            if hasattr(structure, 'viewdockx_data'):
+                structure.register_attr(self.session, "viewdock_data", "ViewDock")
+                structure.viewdock_data = structure.viewdockx_data.copy()
+        return [structure for structure in structures if hasattr(structure, 'viewdock_data')]
 
     def top_buttons_setup(self):
         """
@@ -381,7 +397,7 @@ class ViewDockTool(ToolInstance):
                     "Can only convert ViewDockX version 2 tool instances for ViewDock."
                 )
                 return None
-            return cls(session, "ViewDock", [])
+            return cls(session, "ViewDock", snapshot['structures'])
 
         # ViewDock snapshots
         if snapshot['version'] != 1:

--- a/src/bundles/viewdock/src/tool.py
+++ b/src/bundles/viewdock/src/tool.py
@@ -213,8 +213,10 @@ class ViewDockTool(ToolInstance):
 
         # Add the group box to the main layout
         self.main_v_layout.addWidget(self.description_group)
-        # Select the first structure in the table to display its data in the description box
-        self.struct_table.selected = [self.structures[0]]
+
+        if len(self.structures) > 0:
+            # Select the first structure in the table to display its data in the description box
+            self.struct_table.selected = [self.structures[0]]
 
     def table_selection_changed(self, newly_selected, newly_deselected):
         """

--- a/src/bundles/viewdock/src/tool.py
+++ b/src/bundles/viewdock/src/tool.py
@@ -368,11 +368,28 @@ class ViewDockTool(ToolInstance):
 
     @classmethod
     def restore_snapshot(cls, session, snapshot):
+        """
+        Restore snapshots for the ViewDock tool and the old ViewDockX tool.
+        """
+        # ViewDockX snapshots
+        if 'vdxtable' in snapshot['_html_state']['name']:
+            if snapshot['version'] != 2:
+                session.logger.warning(
+                    f"Incompatible ViewDockX snapshot version {snapshot['version']}. "
+                    "Can only convert ViewDockX version 2 tool instances for ViewDock."
+                )
+                return None
+            return cls(session, "ViewDock", [])
+
+        # ViewDock snapshots
         if snapshot['version'] != 1:
-            session.logger.warning("Incompatible snapshot version for ViewDock tool.")
+            session.logger.warning(
+                f"Incompatible snapshot version {snapshot['version']} for ViewDock tool. "
+                "Expected version 1."
+            )
             return None
-        tool = cls(session, snapshot['tool_name'], snapshot['structures'])
-        return tool
+
+        return cls(session, snapshot['tool_name'], snapshot['structures'])
 
 class RatingDelegate(QStyledItemDelegate):
     """

--- a/src/bundles/viewdock/src/tool.py
+++ b/src/bundles/viewdock/src/tool.py
@@ -390,22 +390,23 @@ class ViewDockTool(ToolInstance):
         Restore snapshots for the ViewDock tool and the old ViewDockX tool.
         """
         # ViewDockX snapshots
-        if 'vdxtable' in snapshot['_html_state']['name']:
-            if snapshot['version'] != 2:
+        try:
+            if 'vdxtable' in snapshot['_html_state']['name']:
+                if snapshot['version'] != 2:
+                    session.logger.warning(
+                        f"Incompatible ViewDockX snapshot version {snapshot['version']}. "
+                        "Can only convert ViewDockX version 2 tool instances for ViewDock."
+                    )
+                    return None
+                return cls(session, "ViewDock", snapshot['structures'])
+        except:
+            # ViewDock snapshots
+            if snapshot['version'] != 1:
                 session.logger.warning(
-                    f"Incompatible ViewDockX snapshot version {snapshot['version']}. "
-                    "Can only convert ViewDockX version 2 tool instances for ViewDock."
+                    f"Incompatible snapshot version {snapshot['version']} for ViewDock tool. "
+                    "Expected version 1."
                 )
                 return None
-            return cls(session, "ViewDock", snapshot['structures'])
-
-        # ViewDock snapshots
-        if snapshot['version'] != 1:
-            session.logger.warning(
-                f"Incompatible snapshot version {snapshot['version']} for ViewDock tool. "
-                "Expected version 1."
-            )
-            return None
 
         return cls(session, snapshot['tool_name'], snapshot['structures'])
 


### PR DESCRIPTION
## Open ViewDockX Sessions in ViewDock

This PR adds support for opening legacy ViewDockX sessions using the updated ViewDock interface, enabling bundle migration and backward compatibility.

### Implementation Details

- **Bundle Name Mapping**  
  The `toolshed` now maps the bundle name `'ChimeraX-ViewDockX'` to `'ChimeraX-ViewDock'`, ensuring all ViewDockX session file UniqueIDs resolve to the new ViewDock bundle.

- **Tool Class Resolution**  
  `viewdock/src/__init__.py` has been updated so that references to the legacy ViewDockX tool (`TableTool`) return the new `ViewDockTool` class.

- **Snapshot Restoration**  
  `ViewDockTool.restore_snapshot()` has been extended to recognize and handle session data from ViewDockX, allowing restoration from legacy snapshots.

- **Structure Compatibility**  
  `ViewDockTool` now filters input to include only structures with a `viewdock_data` attribute (as expected from docking file parsing). For models from ViewDockX sessions, this attribute is registered on tool initialization and populated by copying data from the existing `viewdockx_data` attribute.

### Bug Fixes

- **Empty Structure Handling**  
  Prevents a crash when launching `ViewDockTool` with no structures or no compatible structures by skipping default table selection in those cases.
