### PR TITLE
feature/viewdock/struct-rating-attr

### DIFF
--- a/src/bundles/viewdock/src/__init__.py
+++ b/src/bundles/viewdock/src/__init__.py
@@ -22,6 +22,9 @@
 
 from chimerax.core.toolshed import BundleAPI
 
+RATING_KEY = 'rating'
+DEFAULT_RATING = 2
+
 class _MyAPI(BundleAPI):
     api_version = 1
 

--- a/src/bundles/viewdock/src/io.py
+++ b/src/bundles/viewdock/src/io.py
@@ -20,6 +20,8 @@
 # copies, of the software or any revisions or derivations thereof.
 # === UCSF ChimeraX Copyright ===
 
+from chimerax.viewdock import RATING_KEY, DEFAULT_RATING
+
 def open_mol2(session, path, file_name, auto_style, atomic):
     from chimerax.io import open_input
     with open_input(path, encoding='utf-8') as stream:
@@ -162,7 +164,7 @@ class Mol2Parser:
 
     def _reset_structure(self):
         """Reset structure data cache"""
-        self._data = {}
+        self._data = {RATING_KEY: DEFAULT_RATING}
         self._molecule = None
         self._atoms = []
         self._bonds = []
@@ -518,7 +520,7 @@ def open_swissdock(session, stream, file_name, auto_style, atomic):
     is_ligands = True
     used_chains = set()
     cur_in_chain = cur_out_chain = cur_res_num = None
-    viewdock_data = {}
+    viewdock_data = {RATING_KEY: DEFAULT_RATING}
     models = []
     status = ""
     from chimerax.pdb import open_pdb
@@ -556,7 +558,7 @@ def open_swissdock(session, stream, file_name, auto_style, atomic):
                     models.append(lig)
                 os.unlink(out_f.name)
                 out_f = tempfile.NamedTemporaryFile(mode='w', encoding='utf-8', suffix=".pdb", delete=False)
-                viewdock_data = {}
+                viewdock_data = {RATING_KEY: DEFAULT_RATING}
         elif line.startswith("REMARK"):
             if line.count(': ') != 1:
                 is_ligands = False

--- a/src/bundles/viewdock/src/pdbqt.py
+++ b/src/bundles/viewdock/src/pdbqt.py
@@ -20,6 +20,8 @@
 # copies, of the software or any revisions or derivations thereof.
 # === UCSF ChimeraX Copyright ===
 
+from chimerax.viewdock import RATING_KEY, DEFAULT_RATING
+
 def open_pdbqt(*args):
     encodings = ['utf-8', 'utf-16', 'utf-32']
     for encoding in encodings:
@@ -71,7 +73,7 @@ def _extract_metadata(session, f, structures):
     """
     in_model = False
     model_index = -1
-    vina_values = {}
+    vina_values = {RATING_KEY: DEFAULT_RATING}
     vina_labels = ["Score", "RMSD l.b.", "RMSD u.b."]
     vina_marker = "VINA RESULT:"
     for line in f:
@@ -89,5 +91,5 @@ def _extract_metadata(session, f, structures):
                 from chimerax.atomic import Structure as SC
                 SC.register_attr(session, "viewdock_data", "ViewDock")
                 structures[model_index].viewdock_data = vina_values
-                vina_values = {}
+                vina_values = {RATING_KEY: DEFAULT_RATING}
             in_model = False

--- a/src/bundles/viewdock/src/tool.py
+++ b/src/bundles/viewdock/src/tool.py
@@ -214,10 +214,10 @@ class ViewDockTool(ToolInstance):
         self.struct_table.setEditTriggers(QAbstractItemView.EditTrigger.CurrentChanged)
 
         # Collect all unique keys from viewdock_data of all structures and add them as columns
-        viewdockx_keys = set()
+        viewdock_keys = set()
         for structure in self.structures:
-            viewdockx_keys.update(structure.viewdock_data.keys())
-        for key in viewdockx_keys:
+            viewdock_keys.update(structure.viewdock_data.keys())
+        for key in viewdock_keys:
             if key == RATING_KEY:
                 # Rating is already added as a column with a custom delegate, skip it here
                 continue

--- a/src/bundles/viewdock/src/tool.py
+++ b/src/bundles/viewdock/src/tool.py
@@ -46,6 +46,16 @@ class ViewDockTool(ToolInstance):
     registered_mousemode = False
 
     def __init__(self, session, tool_name, structures):
+        """
+        Initialize the ViewDock tool with, table, table controls, and model descriptions.
+
+        Args:
+            session: The ChimeraX session.
+            tool_name (str): The name of the tool. Used for saving settings.
+            structures: A list of structures to display in the tool. Structures must have the .viewdock_data attribute
+            with at minimum a rating key. ex {'rating': 2, 'name': 'Docked Structure 1', 'energy_score': -5.0, ...}
+        """
+
         super().__init__(session, tool_name)
         self.display_name = "ViewDock"
 

--- a/src/bundles/viewdock/src/tool.py
+++ b/src/bundles/viewdock/src/tool.py
@@ -218,6 +218,9 @@ class ViewDockTool(ToolInstance):
         for structure in self.structures:
             viewdockx_keys.update(structure.viewdock_data.keys())
         for key in viewdockx_keys:
+            if key == RATING_KEY:
+                # Rating is already added as a column with a custom delegate, skip it here
+                continue
             self.struct_table.add_column(key, lambda s, k=key: s.viewdock_data.get(k, ''))
 
         # Set the data for the table and launch it

--- a/src/bundles/viewdock/src/tool.py
+++ b/src/bundles/viewdock/src/tool.py
@@ -36,6 +36,7 @@ from Qt.QtWidgets import (QStyledItemDelegate, QComboBox, QAbstractItemView, QVB
                           QHBoxLayout, QPushButton, QDialog, QDialogButtonBox, QGroupBox, QGridLayout, QLabel, QWidget,)
 from Qt.QtGui import QFont
 from Qt.QtCore import Qt
+from chimerax.viewdock import RATING_KEY, DEFAULT_RATING
 
 
 class ViewDockTool(ToolInstance):
@@ -190,7 +191,7 @@ class ViewDockTool(ToolInstance):
 
         # Custom Rating delegate
         delegate = RatingDelegate(self.struct_table)  # Create the delegate instance
-        self.struct_table.add_column('Rating', lambda s: s.viewdock_data.get('Rating', 2),
+        self.struct_table.add_column('Rating', lambda s: s.viewdock_data.get(RATING_KEY),
                                      data_set = lambda item, value: None,
                                      editable=True)
 
@@ -489,7 +490,7 @@ class RatingDelegate(QStyledItemDelegate):
         # Get the structure (chimerax Structure) from the table row.
         structure = self.parent().data[index.row()]
         new_rating = int(editor.currentText())
-        structure.viewdock_data['Rating'] = new_rating  # Update the rating in the structure's data
+        structure.viewdock_data[RATING_KEY] = new_rating  # Update the rating in the structure's data
 
         model.setData(index, new_rating)  # Optionally, set the value in the model too. This is for Qt completeness
 


### PR DESCRIPTION
## Feature: Add Default 'rating' Attribute in ViewDock Data

### Summary
This PR ensures that a `rating` key is always initialized in the `viewdock_data` dictionary for all supported file types parsed by ViewDock. Previously, the `rating` attribute would only be initialized for the structure if explicitly set through the table interface.

### Changes Introduced
- Defined module-level constants in `__init__.py`:
  - `RATING_KEY = 'rating'`
  - `DEFAULT_RATING = 2`
- Updated file parsers (`mol2`, `swissdock`, `pdbqt`) to initialize `viewdock_data` with `{RATING_KEY: DEFAULT_RATING}` alongside other parsed metadata.
- Modified `ViewDockTool`:
  - Table column setup now uses `RATING_KEY` instead of hardcoded strings.
  - `setModelData` updates `viewdock_data[RATING_KEY]` rather than explicit `viewdock_data['Rating']`.