### PR TITLE
fix import in segmentations: bundle.py

### DIFF
--- a/src/bundles/segmentations/src/bundle.py
+++ b/src/bundles/segmentations/src/bundle.py
@@ -65,6 +65,6 @@ class SegmentationsBundle(BundleAPI):
     @staticmethod
     def run_provider(session, name, mgr, **_):
         if mgr == session.toolbar:
-            from chmerax.segmentations.actions import run_toolbar_button
+            from chimerax.segmentations.actions import run_toolbar_button
 
             return run_toolbar_button(session, name)


### PR DESCRIPTION
Issue:

Options in segmentation controls throw an error due to incorrect import.

Fix: 

Changes import from "chmerax" to "chimerax" in segmentations/bundle.py