### PR TITLE
build: Use a patched PyOpenGL_accelerate on Mac Intel/Linux ARM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,8 @@ prereqs/pips/grako*.whl
 prereqs/pips/tinyarray*.whl
 prereqs/pips/Cython*.whl
 prereqs/pips/PyOpenGL*.whl
+prereqs/pips/pyopengl_accelerate*.tar.gz
+prereqs/pips/pyopengl_accelerate-3.1.9
 prereqs/pips/*.dylib.arm64
 prereqs/pips/*.dylib
 prereqs/pips/qtshim*.whl

--- a/prereqs/pips/Makefile
+++ b/prereqs/pips/Makefile
@@ -103,6 +103,8 @@ ifdef USE_PYSIDE6
 endif
 ifneq ($(filter $(OSARCH),DarwinIntel64 LinuxArm64),)
 	$(APP_PIP_INSTALL) $(PYOPENGL_WHEEL)
+else
+	$(APP_PIP_INSTALL) $(shell grep PyOpenGL-accelerate $(TOP)/pyproject.toml | sed -e 's/[\ #",]//g')
 endif
 ifneq (,$(SOURCE_WHEELS))
 	LANG=$(LANG) $(PIP_INSTALL) --no-build-isolation --no-binary $(subst $(SPACE),$(COMMA),$(SOURCE_WHEELS)) $(SOURCE_VERSIONS)

--- a/prereqs/pips/Makefile
+++ b/prereqs/pips/Makefile
@@ -50,7 +50,7 @@ ifeq ($(OS),Windows)
 else
 ifeq ($(OS),Linux)
 ifeq ($(OSARCH),LinuxArm64)
-PYOPENGL_WHEEL = PyOpenGL_accelerate-3.1.9-cp311-cp311-linux_aarch64.whl
+PYOPENGL_WHEEL = pyopengl_accelerate-3.1.9-cp311-cp311-linux_aarch64.whl
 else
 endif
 else
@@ -60,7 +60,7 @@ ifeq ($(OSARCH),DarwinArm64)
 SCIPY_WHEEL = $(subst ==,-,$(shell grep scipy $(TOP)/pyproject.toml | sed -e 's/[\ ",]//g'))-cp311-cp311-macosx_12_0_arm64.whl
 else
 ifeq ($(OSARCH),DarwinIntel64)
-PYOPENGL_WHEEL = PyOpenGL_accelerate-3.1.9-cp311-cp311-macosx_10_9_x86_64.whl
+PYOPENGL_WHEEL = pyopengl_accelerate-3.1.9-cp311-cp311-macosx_10_9_x86_64.whl
 endif
 endif
 endif

--- a/prereqs/pips/Makefile
+++ b/prereqs/pips/Makefile
@@ -89,6 +89,7 @@ app-install: app_requirements.txt $(PLATO_WHEELS) $(SCIPY_WHEEL)
 else
 app-install: app_requirements.txt $(PLATO_WHEELS)
 endif
+endif
 	# Install Cython first so PyOpenGL_accelerate builds
 	$(APP_PIP_INSTALL) $(CYTHON_BUILD_ARGS) $(shell grep Cython $(TOP)/pyproject.toml | sed -e 's/[\ #",]//g')
 	$(APP_PIP_INSTALL) $(shell grep numpy app_requirements.txt | sed -e 's/[\ #",]//g')

--- a/prereqs/pips/Makefile
+++ b/prereqs/pips/Makefile
@@ -44,10 +44,13 @@ else
 CYTHON_BUILD_ARGS=
 endif
 
+PYOPENGL_SRC = pyopengl_accelerate-3.1.9.tar.gz
+
 ifeq ($(OS),Windows)
 else
 ifeq ($(OS),Linux)
 ifeq ($(OSARCH),LinuxArm64)
+PYOPENGL_WHEEL = PyOpenGL_accelerate-3.1.9-cp311-cp311-linux_aarch64.whl
 else
 endif
 else
@@ -57,6 +60,7 @@ ifeq ($(OSARCH),DarwinArm64)
 SCIPY_WHEEL = $(subst ==,-,$(shell grep scipy $(TOP)/pyproject.toml | sed -e 's/[\ ",]//g'))-cp311-cp311-macosx_12_0_arm64.whl
 else
 ifeq ($(OSARCH),DarwinIntel64)
+PYOPENGL_WHEEL = PyOpenGL_accelerate-3.1.9-cp311-cp311-macosx_10_9_x86_64.whl
 endif
 endif
 endif
@@ -77,6 +81,9 @@ app-list:
 
 upgrade:
 
+ifneq ($(filter $(OSARCH),DarwinIntel64 LinuxArm64),)
+app-install: app_requirements.txt $(PLATO_WHEELS) patched-pyopengl
+else
 ifeq ($(OSARCH),DarwinArm64)
 app-install: app_requirements.txt $(PLATO_WHEELS) $(SCIPY_WHEEL)
 else
@@ -92,6 +99,9 @@ endif
 ifdef USE_PYSIDE6
 	$(APP_PIP_INSTALL) $(shell grep PySide6 $(TOP)/pyproject.toml | sed -e 's/[\ #",]//g')
 	$(APP_PIP_INSTALL) $(shell grep shiboken6 $(TOP)/pyproject.toml | sed -e 's/[\ #",]//g')
+endif
+ifneq ($(filter $(OSARCH),DarwinIntel64 LinuxArm64),)
+	$(APP_PIP_INSTALL) $(PYOPENGL_WHEEL)
 endif
 ifneq (,$(SOURCE_WHEELS))
 	LANG=$(LANG) $(PIP_INSTALL) --no-build-isolation --no-binary $(subst $(SPACE),$(COMMA),$(SOURCE_WHEELS)) $(SOURCE_VERSIONS)
@@ -153,6 +163,8 @@ app-upgrade:
 clean:
 	-rm -f pip.log
 	-rm -f app_requirements.txt
+	-rm -f pyopengl_accelerate-3.1.9.tar.gz
+	-rm -rf pyopengl_accelerate-3.1.9
 	make -C package_checker clean
 
 outdated:
@@ -176,6 +188,17 @@ app-outdated:
 
 src-outdated:
 	$(PYTHON_EXE) -m package_checker ../../src
+
+ifneq ($(filter $(OSARCH),DarwinIntel64 LinuxArm64),)
+$(PYOPENGL_SRC):
+	$(APP_PIP) download --no-build-isolation --no-binary=:all: $(shell grep PyOpenGL $(TOP)/pyproject.toml | sed 's/[\ ",#]//g')
+
+patched-pyopengl: $(PYOPENGL_SRC)
+	tar --no-same-owner -xf $(PYOPENGL_SRC)
+	patch -N -p0 < pyopengl_accelerate.patch
+	$(APP_PIP) -m build --wheel pyopengl_accelerate-3.1.9
+	mv pyopengl_accelerate-3.1.9/dist/$(PYOPENGL_WHEEL) .
+endif
 
 $(SCIPY_WHEEL):
 	$(APP_PIP) download --platform=macosx_12_0_arm64 --no-deps $(shell grep scipy $(TOP)/pyproject.toml | sed 's/[\ ",]//g')

--- a/prereqs/pips/Makefile
+++ b/prereqs/pips/Makefile
@@ -197,7 +197,7 @@ $(PYOPENGL_SRC):
 patched-pyopengl: $(PYOPENGL_SRC)
 	tar --no-same-owner -xf $(PYOPENGL_SRC)
 	patch -N -p0 < pyopengl_accelerate.patch
-	$(APP_PIP) -m build --wheel pyopengl_accelerate-3.1.9
+	$(APP_PYTHON_BIN) -m build --wheel pyopengl_accelerate-3.1.9
 	mv pyopengl_accelerate-3.1.9/dist/$(PYOPENGL_WHEEL) .
 endif
 

--- a/prereqs/pips/pyopengl_accelerate.patch
+++ b/prereqs/pips/pyopengl_accelerate.patch
@@ -1,0 +1,92 @@
+diff --color -rp pyopengl_accelerate-3.1.9.old/pyproject.toml pyopengl_accelerate-3.1.9/pyproject.toml
+*** pyopengl_accelerate-3.1.9.old/pyproject.toml	2025-01-19 16:30:48
+--- pyopengl_accelerate-3.1.9/pyproject.toml	2025-07-30 13:50:18
+*************** dynamic=["version"]
+*** 1,6 ****
+--- 1,7 ----
+  [project]
+  name="PyOpenGL-accelerate"
+  dynamic=["version"]
++ requires-python = ">= 3.9" # At least Python 3.9
+  description = "Cython-coded accelerators for PyOpenGL"
+  authors = [
+      {name="Mike C. Fletcher",email="mcfletch@vrplumber.com"},
+*************** classifiers = [
+*** 23,29 ****
+  classifiers = [
+      "License :: OSI Approved :: BSD License",
+      "Programming Language :: Python",
+-     "Programming Language :: Python :: 2",
+      "Programming Language :: Python :: 3",
+      "Topic :: Multimedia :: Graphics :: 3D Rendering",
+      "Topic :: Software Development :: Libraries :: Python Modules",
+--- 24,29 ----
+*************** Documentation = "https://mcfletch.github.io/pyopengl/d
+*** 36,42 ****
+  Documentation = "https://mcfletch.github.io/pyopengl/documentation/index.html"
+  
+  [build-system]
+! requires = [ "setuptools >= 42.0", "Cython >= 0.28", "numpy" ]
+  build-backend = "setuptools.build_meta"
+  
+  [tool.setuptools.dynamic]
+--- 36,42 ----
+  Documentation = "https://mcfletch.github.io/pyopengl/documentation/index.html"
+  
+  [build-system]
+! requires = [ "setuptools >= 42.0", "Cython >= 3", "numpy" ]
+  build-backend = "setuptools.build_meta"
+  
+  [tool.setuptools.dynamic]
+*************** include=["OpenGL_accelerate"]
+*** 45,49 ****
+  [tool.setuptools.packages.find]
+  namespaces=false
+  include=["OpenGL_accelerate"]
+! exclude=["tests","src"]
+  
+--- 45,49 ----
+  [tool.setuptools.packages.find]
+  namespaces=false
+  include=["OpenGL_accelerate"]
+! exclude=["tests", "src"]
+  
+diff --color -rp pyopengl_accelerate-3.1.9.old/src/vbo.pyx pyopengl_accelerate-3.1.9/src/vbo.pyx
+*** pyopengl_accelerate-3.1.9.old/src/vbo.pyx	2025-01-19 16:30:48
+--- pyopengl_accelerate-3.1.9/src/vbo.pyx	2025-07-30 13:50:18
+*************** cdef class VBO:
+*** 188,195 ****
+          assert not self.created, """Already created the buffer"""
+          buffers = self.get_implementation().glGenBuffers(1)
+          try:
+!             self.buffer = long( buffers )
+!         except (TypeError,ValueError) as err:
+              self.buffer = buffers[0]
+          self.target = self.c_resolve( self.target_spec )
+          self.usage = self.c_resolve( self.usage_spec )
+--- 188,195 ----
+          assert not self.created, """Already created the buffer"""
+          buffers = self.get_implementation().glGenBuffers(1)
+          try:
+!             self.buffer = int( buffers )
+!         except (TypeError, ValueError) as err:
+              self.buffer = buffers[0]
+          self.target = self.c_resolve( self.target_spec )
+          self.usage = self.c_resolve( self.usage_spec )
+*************** cdef class VBO:
+*** 242,248 ****
+          """Add an integer to this VBO (offset)"""
+          if hasattr( other, 'offset' ):
+              other = other.offset
+!         assert isinstance( other, (int,long) ), """Only know how to add integer/long offsets"""
+          return VBOOffset( self, other )
+      cdef int check_live( self ):
+          if self.data is _NULL:
+--- 242,248 ----
+          """Add an integer to this VBO (offset)"""
+          if hasattr( other, 'offset' ):
+              other = other.offset
+!         assert isinstance( other, int), """Only know how to add integer offsets"""
+          return VBOOffset( self, other )
+      cdef int check_live( self ):
+          if self.data is _NULL:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ file = "README.md"
 gui = [
   "openvr==1.26.701",
   "PyOpenGL==3.1.9",
-  "PyOpenGL-accelerate==3.1.9",
+  #"PyOpenGL-accelerate==3.1.9",
   # PyQt handled in prereqs/PyQt"
   # sip handled in prereqs/PyQt
   #PySide6==6.9.0


### PR DESCRIPTION
Due to mcfletch/pyopengl#147 we have to build accelerate using the patch in mcfletch/pyopengl#155 in order for it to work on mac Intel or linux ARM with Cython >=3.1, which dropped support for Python 2.