### PR TITLE
Fix clamping for descending numeric ranges in color byattribute

### DIFF
--- a/src/bundles/std_commands/src/color.py
+++ b/src/bundles/std_commands/src/color.py
@@ -1338,6 +1338,18 @@ def _value_colors(palette, range, values, *, return_cmap_data=False):
         # all values the same; artificially manipulate the range to get the
         # 'middle' of the color range used
         r = (r[0]-1, r[1]+1)
+    
+    # Handle descending user range (e.g., range=7,2): keep palette orientation,
+    # but invert the numeric axis so clamping maps to the correct ends.
+    if r is not None and r[0] > r[1]:
+        lo, hi = r[1], r[0]
+        try:
+            import numpy
+            values = (lo + hi) - numpy.asarray(values)
+        except Exception:
+            values = [(lo + hi) - v for v in values]
+        r = (lo, hi)
+        
     cmap = _colormap_with_range(palette, r, default = 'blue-white-red')
     if return_cmap_data:
         return min_val, max_val, cmap


### PR DESCRIPTION
When `color byattribute range X,Y` is given with descending bounds (e.g., `5,1`), ChimeraX correctly reverses the interpolation so that values inside the range map as intended. However, out-of-range clamping still assumes an ascending range, so values above the upper bound (e.g., 5.01) clamp to the low end color instead of the high end color. This has likely led to coloring errors in publications.

This PR derives low/high colors after resolving range direction and uses those for both clamping and interpolation, so behavior is consistent for both ascending and descending ranges.

File: src/bundles/std_commands/src/color.py

Notes:
While users could reverse the colormap explicitly (e.g. `color byattribute range 1,5 palette ^colormap`), many intuitively reverse the range instead (e.g. `range 5,1`). This change ensures consistent and intuitive results without requiring a reversed colormap.