### PR TITLE
Add string() method to the Volume class to avoid AttributeError when …

### DIFF
--- a/src/bundles/map/src/volume.py
+++ b/src/bundles/map/src/volume.py
@@ -144,6 +144,29 @@ class Volume(Model):
 
   # ---------------------------------------------------------------------------
   #
+  def string(self, style=None):
+    '''Return a human-readable string for this volume model.
+    
+    Parameters
+    ----------
+    style : str or None
+        If "command" or starts with "command", returns just the atomspec (e.g., "#1").
+        Otherwise, returns the name and atomspec (e.g., "myvolume #1").
+    
+    Returns
+    -------
+    str
+        A string representation of this volume model.
+    '''
+    id = '#' + self.id_string
+    if style is not None and (style == "command" or style.startswith("command")):
+      return id
+    if not self.name:
+      return id
+    return '%s %s' % (self.name, id)
+
+  # ---------------------------------------------------------------------------
+  #
   def info_string(self):
 
     px,py,pz = self.data.step


### PR DESCRIPTION
…opening map file via the REST server with return_json

## Fix AttributeError when opening Volume models via REST API with JSON mode

### Issue

When opening MRC map files through the ChimeraX REST API with JSON mode enabled, the `open` command returns an `AttributeError`:

{
  "error": {
    "type": "AttributeError",
    "message": "'Volume' object has no attribute 'string'"
  }
}This occurs despite the file opening successfully, as evidenced by the success messages in the log output.

### Root Cause

The `open` command implementation (`src/bundles/open_command/src/cmd.py`, line 136) attempts to generate JSON output by calling the `string()` method on all opened models:

open_data = { 'model specs': [m.string(style="command") for m in models] }The `string()` method is implemented in the `Structure` class (`src/bundles/atomic/src/structure.py`) to provide a human-readable string representation of atomic structures. However, the `Volume` class (`src/bundles/map/src/volume.py`) inherits from the base `Model` class, which does not implement this method.

When the REST API opens a Volume model (MRC files, etc.) with `return_json=True`, the call to `m.string(style="command")` fails with an AttributeError.

### Solution

Added a `string(style=None)` method to the `Volume` class that follows the same pattern as `Structure.string()`:

- When `style="command"` (or starts with "command"), returns just the atomspec (e.g., `"#1"`)
- Otherwise, returns the name and atomspec (e.g., `"myvolume #1"`)
- Handles cases where the model name is empty

### Changes

**File:** `src/bundles/map/src/volume.py`

Added method at line 147:

def string(self, style=None):
    '''Return a human-readable string for this volume model.
    
    Parameters
    ----------
    style : str or None
        If "command" or starts with "command", returns just the atomspec (e.g., "#1").
        Otherwise, returns the name and atomspec (e.g., "myvolume #1").
    
    Returns
    -------
    str
        A string representation of this volume model.
    '''
    id = '#' + self.id_string
    if style is not None and (style == "command" or style.startswith("command")):
      return id
    if not self.name:
      return id
    return '%s %s' % (self.name, id)### Testing

The fix has been verified by:
1. Building and installing the modified `map` bundle
2. Opening MRC files through the REST API with JSON mode enabled
3. Confirming that the error no longer occurs and the JSON response includes the correct model specification

### Impact

This fix ensures that volumes can be opened by MCP clients without spurious errors confusing things.