### PR TITLE
Print sequence to Log when viewer is suppressed in 'sequence chain' command

### DIFF
--- a/src/bundles/seqalign/src/cmd.py
+++ b/src/bundles/seqalign/src/cmd.py
@@ -268,7 +268,7 @@ def seqalign_chain(session, chains, *, viewer=True):
 
     if viewer is False:
         for seq in alignment.seqs:
-            session.logger.info(seq.characters)
+            session.logger.info(f"{seq.name} {seq.characters}")
 
 def seqalign_associate(session, chains, target=None):
     if target is None:

--- a/src/bundles/seqalign/src/cmd.py
+++ b/src/bundles/seqalign/src/cmd.py
@@ -266,6 +266,10 @@ def seqalign_chain(session, chains, *, viewer=True):
             alignment.associate(chain, keep_intrinsic=True)
         alignment.resume_notify_observers()
 
+    if viewer is False:
+        for seq in alignment.seqs:
+            session.logger.info(seq.characters)
+
 def seqalign_associate(session, chains, target=None):
     if target is None:
         alignments = session.alignments.alignments


### PR DESCRIPTION
When running `sequence chain` with `viewer false`, the sequence characters are now printed to the Log window. Previously, only the alignment identifier was shown, with no way to see the actual sequence without opening a viewer. 

I wanted my agent to be able to easily get the chain sequence, and this seemed like the most straightforward way. Please LMK if I missed something.