### PR TITLE
Add vrto3d (SteamVR) support for autostereo 3D displays

### DIFF
--- a/src/bundles/vive/src/xr.py
+++ b/src/bundles/vive/src/xr.py
@@ -579,7 +579,10 @@ class OpenXRCamera(Camera, StateManager):
 
     @property
     def is_vr_headset(self):
-        return self.openxr_system_name not in ('SonySRD System', 'SpatialLabs Display Driver')
+        name = self.openxr_system_name
+        if 'vrto3d' in name.lower():
+            return False
+        return name not in ('SonySRD System', 'SpatialLabs Display Driver')
 
     @property
     def active(self):

--- a/src/bundles/vive/src/xr_screens.py
+++ b/src/bundles/vive/src/xr_screens.py
@@ -12,8 +12,9 @@
 # === UCSF ChimeraX Copyright ===
 
 # -----------------------------------------------------------------------------
-# Routines to setup OpenXR 3D screens such as Sony Spatial Reality
-# or Acer SpatialLabs to handle the coordinate systems for these displays
+# Routines to setup OpenXR 3D screens such as Sony Spatial Reality,
+# Acer SpatialLabs, or Samsung Odyssey 3D (via SteamVR vrto3d driver)
+# to handle the coordinate systems for these displays
 # and mouse events and keyboard input.
 #
 def setup_openxr_screen(openxr_system_name, openxr_camera):
@@ -21,6 +22,8 @@ def setup_openxr_screen(openxr_system_name, openxr_camera):
         _sony_spatial_reality_setup(openxr_camera)
     elif openxr_system_name == 'SpatialLabs Display Driver':
         _acer_spatial_labs_setup(openxr_camera)
+    elif 'vrto3d' in openxr_system_name.lower():
+        _vrto3d_screen_setup(openxr_camera)
 
 def _sony_spatial_reality_setup(openxr_camera):
     # Flatpanel Sony Spatial Reality display with eye tracking.
@@ -34,7 +37,7 @@ def _sony_spatial_reality_setup(openxr_camera):
         w,h = 0.58*scale, 0.33*scale
     else:
         w,h = 0.34, 0.19	# Screen size meters
-        
+
     from math import sqrt
     s2 = 1/sqrt(2)
     from numpy import array
@@ -105,23 +108,46 @@ def _acer_spatial_labs_setup(openxr_camera):
 
     _enable_xr_mouse_modes(c._session)
 
+def _vrto3d_screen_setup(openxr_camera):
+    # SteamVR vrto3d driver used with autostereo 3D displays such as
+    # Samsung Odyssey 3D (flat vertical panel with eye tracking).
+    # vrto3d emulates a VR headset via SteamVR so that OpenXR apps
+    # produce stereo output which vrto3d converts to SBS for the
+    # display's lenticular lens and eye tracking.
+    #
+    # Unlike Sony/Acer which use native OpenXR screen drivers,
+    # vrto3d goes through SteamVR which handles room positioning.
+    # We only need to enable mouse modes here -- no fit_view_to_room().
+    #
+    # direct_pick: vrto3d per-eye render is portrait (e.g. 1920x2160)
+    # while the screen is landscape. The standard coordinate mapping
+    # through the graphics pane loses accuracy due to aspect ratio
+    # mismatch. direct_pick maps backing window coordinates directly
+    # to the XR render texture, bypassing the graphics pane.
+    _enable_xr_mouse_modes(openxr_camera._session,
+                           openxr_window_captures_events = True,
+                           direct_pick = True)
+
 def _enable_xr_mouse_modes(session, screen_model_name = None,
-                           openxr_window_captures_events = False):
+                           openxr_window_captures_events = False,
+                           direct_pick = False):
     '''
-    Allow mouse modes to work with mouse on Acer or Sony 3D displays.
-    Both these displays create a fullscreen window. This mouse mode support
+    Allow mouse modes to work with mouse on Acer, Sony, or Samsung 3D displays.
+    These displays create a fullscreen window. This mouse mode support
     works by creating a backing full-screen Qt window which receives the
-     mouse events.
+    mouse events.
     '''
     screen = find_xr_screen(session, screen_model_name)
     if screen is None:
         session.logger.warning('Could not enable mouse on OpenXR screen.')
         return False
-    XRBackingWindow(session, screen, in_front = openxr_window_captures_events)
+    XRBackingWindow(session, screen, in_front = openxr_window_captures_events,
+                    direct_pick = direct_pick)
     session.logger.info(f'Enabled mouse on OpenXR screen "{screen.model()}"')
     return True
 
-xr_screen_model_names = ['ASV27-2P', '1ASV27-2P', 'DS1_156', 'SR Display', 'SR Display GB']
+xr_screen_model_names = ['ASV27-2P', '1ASV27-2P', 'DS1_156', 'SR Display', 'SR Display GB',
+                         'Odyssey G90XF', 'Odyssey G90XH']
 def find_xr_screen(session, screen_model_name = None):
     model_names = [screen_model_name] if screen_model_name else xr_screen_model_names
     screens = session.ui.screens()
@@ -139,20 +165,22 @@ class XRBackingWindow:
     and Sony Spatial Reality to capture mouse and keyboard events when
     mouse is on the 3D display.
     '''
-    def __init__(self, session, screen, in_front = False, hover_text = True):
+    def __init__(self, session, screen, in_front = False, hover_text = True,
+                 direct_pick = False):
         self._session = session
         self._screen = screen
-        
+        self._direct_pick = direct_pick
+
         # Create fullscreen backing Qt window on openxr screen.
         from Qt.QtWidgets import QWidget
         self._widget = w = QWidget()
 
         if in_front:
             self._make_transparent_in_front(w)
-        
+
         w.move(screen.geometry().topLeft())
         w.showFullScreen()
-        
+
         self._register_mouse_handlers()
 
         # Forward key press events
@@ -165,7 +193,7 @@ class XRBackingWindow:
         if hover_text:
             session.triggers.add_handler('graphics update',
                                          self._check_for_mouse_hover)
-        
+
     def _make_transparent_in_front(self, w):
         # On Sony Spatial Reality displays the full screen
         # window made by Sony OpenXR captures mouse events
@@ -219,7 +247,10 @@ class XRBackingWindow:
         graphics pane coordinates and dispatch it.
         '''
         p = event.position()
-        gx, gy = self._backing_to_graphics_coordinates(p.x(), p.y())
+        if self._direct_pick:
+            gx, gy = self._backing_to_render_coordinates(p.x(), p.y())
+        else:
+            gx, gy = self._backing_to_graphics_coordinates(p.x(), p.y())
         e = self._repositioned_event(event, gx, gy)
         mm = self._session.ui.mouse_modes
         mm._dispatch_mouse_event(e, action)
@@ -258,6 +289,36 @@ class XRBackingWindow:
         gx, gy = afx * gw, afy * gh
         return gx, gy
 
+    def _backing_to_render_coordinates(self, x, y):
+        '''
+        Map backing window coordinates directly to the XR per-eye
+        render texture, bypassing the graphics pane aspect ratio
+        correction. This is needed for vrto3d where the per-eye render
+        (e.g. 1920x2160 portrait) has a very different aspect ratio from
+        the graphics pane (e.g. 1979x1163 landscape).
+
+        We compute what graphics pane coordinates would make ray()
+        sample the correct position in the render texture by inverting
+        the texture coordinate mapping that ray() applies.
+        '''
+        w3d = self._widget
+        w, h = w3d.width(), w3d.height()
+        if w == 0 or h == 0:
+            return x, y
+        cam = self._session.main_view.camera
+        td = getattr(cam, '_texture_drawing', None)
+        if td is None or td.texture is None:
+            return self._backing_to_graphics_coordinates(x, y)
+        fx, fy = x / w, y / h
+        tc = td.texture_coordinates
+        (xmin, ymin), (xmax, ymax) = tc[0], tc[2]
+        gw, gh = self._session.main_view.window_size
+        if (xmax - xmin) == 0 or (ymax - ymin) == 0:
+            return self._backing_to_graphics_coordinates(x, y)
+        gx = (fx - xmin) / (xmax - xmin) * gw
+        gy = (fy - ymin) / (ymax - ymin) * gh
+        return gx, gy
+
     def _repositioned_event(self, event, x, y):
         from Qt.QtGui import QMouseEvent, QWheelEvent
         from Qt.QtCore import QPointF
@@ -275,7 +336,7 @@ class XRBackingWindow:
         cp = QCursor.pos()
         if self._session.ui.topLevelAt(cp) == self._widget:
             p = self._widget.mapFromGlobal(cp)
-            x,y = self._map_event_coordinates(p.x(), p.y())
+            x,y = self._backing_to_graphics_coordinates(p.x(), p.y())
             return (int(x), int(y))
         else:
             mm = self._session.ui.mouse_modes
@@ -285,6 +346,9 @@ class XRBackingWindow:
     def _check_for_mouse_hover(self, *args):
         if self._widget is None:
             return 'delete handler'
+        mm = self._session.ui.mouse_modes
+        if not hasattr(mm, 'mouse_paused'):
+            return 'delete handler'  # Not supported in this ChimeraX version
         from Qt.QtGui import QCursor
         cp = QCursor.pos()
         if self._session.ui.topLevelAt(cp) != self._widget:
@@ -292,7 +356,6 @@ class XRBackingWindow:
 
         bp = self._widget.mapFromGlobal(cp)
         x,y = self._backing_to_graphics_coordinates(bp.x(), bp.y())
-        mm = self._session.ui.mouse_modes
         paused, unpaused = mm.mouse_paused((int(x),int(y)))
         if not paused and not unpaused:
             return
@@ -340,7 +403,7 @@ class XRBackingWindow:
         else:
             pick = object = label_type = None
         return pick, object, label_type
-    
+
     def _xr_quit(self, *args):
         self._hide_hover_label()
         # Delete the backing window


### PR DESCRIPTION
## Summary

Adds support for 3D displays that use the [vrto3d](https://github.com/oneup03/VRto3D) SteamVR driver to work with ChimeraX's XR mode. This enables glasses-free autostereo molecular visualization on displays such as the Samsung Odyssey 3D (G90XF 27" / G90XH 32").

### Background

vrto3d is an open-source SteamVR driver that emulates a VR headset, producing side-by-side stereo output that the display's lenticular lens and eye tracking converts to glasses-free 3D. Unlike the Sony Spatial Reality and Acer SpatialLabs which use native OpenXR screen drivers, vrto3d goes through SteamVR which handles room positioning.

### Changes

**xr_screens.py:**
- Detect vrto3d via OpenXR system name (e.g. `"SteamVR/OpenXR : vrto3d"`)
- Add `_vrto3d_screen_setup()` — enables mouse modes only, no `fit_view_to_room()` (SteamVR handles positioning)
- Add Samsung Odyssey screen models (`Odyssey G90XF`, `Odyssey G90XH`) to recognized display list
- Add `direct_pick` coordinate mapping to `XRBackingWindow`: vrto3d's per-eye render is portrait (e.g. 1920×2160) while the screen is landscape — the standard coordinate mapping through the graphics pane loses accuracy due to aspect ratio mismatch. `direct_pick` maps backing window coordinates directly to the XR render texture by inverting the texture coordinate mapping that `ray()` applies. Sony/Acer don't need this because their render aspect ratio matches their screen.
- Add `hasattr` guard for `mouse_paused` (missing in older ChimeraX builds)
- Fix `_graphics_cursor_position` calling nonexistent `_map_event_coordinates` (should be `_backing_to_graphics_coordinates`)

**xr.py:**
- Update `is_vr_headset` property to return `False` for vrto3d (it's a flat screen, not a headset)

### Testing

Tested on Samsung Odyssey 3D G90XF (27" 4K) with vrto3d v0.4.x via SteamVR. Verified:
- `xr on` produces correct stereo output through vrto3d → SBS → lenticular pipeline
- Mouse rotation, zoom, and drag work via backing window
- Atom/residue/bond selection works accurately with `direct_pick`
- Hover labels display correctly
- `xr off` cleanly removes backing window
- No regressions for existing Sony/Acer code paths (changes are additive)

### Use case

The vrto3d driver is used by the glasses-free 3D display community to run any SteamVR-compatible application on autostereo monitors. This includes Samsung Odyssey 3D, and potentially other current and future lenticular/eye-tracking displays that lack native OpenXR drivers. Adding vrto3d recognition to ChimeraX enables these displays for molecular visualization without requiring display manufacturers to ship their own OpenXR drivers.