### PR TITLE
Add 3D cursor and selection for autostereo displays

### DIFF
--- a/src/bundles/vive/src/xr_screens.py
+++ b/src/bundles/vive/src/xr_screens.py
@@ -126,11 +126,13 @@ def _vrto3d_screen_setup(openxr_camera):
     # to the XR render texture, bypassing the graphics pane.
     _enable_xr_mouse_modes(openxr_camera._session,
                            openxr_window_captures_events = True,
-                           direct_pick = True)
+                           direct_pick = True,
+                           cursor_3d = True)
 
 def _enable_xr_mouse_modes(session, screen_model_name = None,
                            openxr_window_captures_events = False,
-                           direct_pick = False):
+                           direct_pick = False,
+                           cursor_3d = False):
     '''
     Allow mouse modes to work with mouse on Acer, Sony, or Samsung 3D displays.
     These displays create a fullscreen window. This mouse mode support
@@ -142,7 +144,7 @@ def _enable_xr_mouse_modes(session, screen_model_name = None,
         session.logger.warning('Could not enable mouse on OpenXR screen.')
         return False
     XRBackingWindow(session, screen, in_front = openxr_window_captures_events,
-                    direct_pick = direct_pick)
+                    direct_pick = direct_pick, cursor_3d = cursor_3d)
     session.logger.info(f'Enabled mouse on OpenXR screen "{screen.model()}"')
     return True
 
@@ -159,6 +161,390 @@ def find_xr_screen(session, screen_model_name = None):
     session.logger.warning(msg)
     return None
 
+_CURSOR_STYLES = ('sphere', 'crosshair', 'diamond', 'arrow', 'pointer')
+
+def _crosshair_geometry(size):
+    '''Three orthogonal thin rectangular prisms forming a 3D crosshair.'''
+    import numpy as np
+    arm = size
+    t = size * 0.1  # Half-thickness of each arm
+    verts = []
+    norms = []
+    tris = []
+    for axis in range(3):
+        ext = [t, t, t]
+        ext[axis] = arm
+        hx, hy, hz = ext
+        o = len(verts)
+        v = [[-hx,-hy,-hz], [hx,-hy,-hz], [hx,hy,-hz], [-hx,hy,-hz],
+             [-hx,-hy, hz], [hx,-hy, hz], [hx,hy, hz], [-hx,hy, hz]]
+        verts.extend(v)
+        for p in v:
+            n = np.array(p, dtype=np.float32)
+            mag = np.linalg.norm(n)
+            norms.append(n / mag if mag > 0 else np.array([0,1,0], dtype=np.float32))
+        tris.extend([
+            [o+0,o+2,o+1], [o+0,o+3,o+2],
+            [o+4,o+5,o+6], [o+4,o+6,o+7],
+            [o+0,o+1,o+5], [o+0,o+5,o+4],
+            [o+2,o+3,o+7], [o+2,o+7,o+6],
+            [o+0,o+4,o+7], [o+0,o+7,o+3],
+            [o+1,o+2,o+6], [o+1,o+6,o+5],
+        ])
+    return np.array(verts, np.float32), np.array(norms, np.float32), np.array(tris, np.int32)
+
+def _diamond_geometry(size):
+    '''Octahedron (diamond) shape.'''
+    import numpy as np
+    s = size
+    verts = np.array([
+        [ s, 0, 0], [-s, 0, 0],
+        [ 0, s, 0], [ 0,-s, 0],
+        [ 0, 0, s], [ 0, 0,-s],
+    ], dtype=np.float32)
+    norms = np.array([
+        [1,0,0], [-1,0,0], [0,1,0], [0,-1,0], [0,0,1], [0,0,-1],
+    ], dtype=np.float32)
+    tris = np.array([
+        [0,2,4], [2,1,4], [1,3,4], [3,0,4],
+        [2,0,5], [1,2,5], [3,1,5], [0,3,5],
+    ], dtype=np.int32)
+    return verts, norms, tris
+
+def _arrow_geometry(size):
+    '''3D cone pointer — tip at origin, base extends in +Y.
+    Tip sits on the surface; base points toward the camera.'''
+    import numpy as np
+    length = size * 5     # Cone length (visible in stereo)
+    base_r = size * 0.6   # Base radius
+    n_seg = 16
+    # Tip at origin
+    verts = [[0, 0, 0]]
+    norms = [[0, -1, 0]]  # Tip normal points down
+    # Base circle at +length (away from surface, toward camera)
+    angles = np.linspace(0, 2 * np.pi, n_seg, endpoint=False)
+    slope = base_r / length
+    for a in angles:
+        ca, sa = np.cos(a), np.sin(a)
+        verts.append([base_r * ca, length, base_r * sa])
+        nx, nz = ca, sa
+        ny = -slope
+        mag = np.sqrt(nx*nx + ny*ny + nz*nz)
+        norms.append([nx/mag, ny/mag, nz/mag])
+    # Base center cap
+    bc = len(verts)
+    verts.append([0, length, 0])
+    norms.append([0, 1, 0])
+    # Cone surface triangles
+    tris = []
+    for i in range(n_seg):
+        tris.append([0, 1 + (i + 1) % n_seg, 1 + i])
+    # Base cap triangles
+    for i in range(n_seg):
+        tris.append([bc, 1 + i, 1 + (i + 1) % n_seg])
+    return np.array(verts, np.float32), np.array(norms, np.float32), np.array(tris, np.int32)
+
+def _pointer_geometry(size):
+    '''Classic mouse pointer cursor, extruded with side walls for
+    real 3D depth.  Tip at origin so it sits on the surface;
+    body extends in -Y (toward camera after rotation).'''
+    import numpy as np
+    s = size
+    t = s * 0.15  # Half-thickness for stereo parallax
+    # Classic arrow cursor silhouette in XY plane, tip at origin
+    tip_y = s * 1.2  # original tip offset, used to centre on tip
+    pts = [
+        [0, 0],                          # 0: tip (at origin)
+        [-s*0.40, -s*0.05 - tip_y],      # 1: left wing
+        [-s*0.12,  s*0.15 - tip_y],      # 2: left notch
+        [-s*0.12, -s*0.55 - tip_y],      # 3: tail bottom-left
+        [ s*0.12, -s*0.55 - tip_y],      # 4: tail bottom-right
+        [ s*0.12,  s*0.15 - tip_y],      # 5: right notch
+        [ s*0.40, -s*0.05 - tip_y],      # 6: right wing
+    ]
+    faces_2d = [
+        [0, 1, 2], [0, 2, 5], [0, 5, 6],  # arrowhead
+        [2, 3, 4], [2, 4, 5],              # tail shaft
+    ]
+    verts = []
+    norms = []
+    tris = []
+    n = len(pts)
+    # Front face (+z)
+    for p in pts:
+        verts.append([p[0], p[1], t])
+        norms.append([0, 0, 1])
+    for f in faces_2d:
+        tris.append(f)
+    # Back face (-z, reversed winding)
+    for p in pts:
+        verts.append([p[0], p[1], -t])
+        norms.append([0, 0, -1])
+    for f in faces_2d:
+        tris.append([n + f[0], n + f[2], n + f[1]])
+    # Side walls (connect front and back outline edges)
+    edges = [(0,1), (1,2), (2,3), (3,4), (4,5), (5,6), (6,0)]
+    base = 2 * n
+    for i, (a, b) in enumerate(edges):
+        pa, pb = pts[a], pts[b]
+        dx, dy = pb[0] - pa[0], pb[1] - pa[1]
+        # Outward normal perpendicular to edge (CCW polygon)
+        nx, ny = dy, -dx
+        mag = np.sqrt(nx*nx + ny*ny)
+        if mag > 0:
+            nx, ny = nx/mag, ny/mag
+        vi = base + i * 4
+        verts.extend([
+            [pa[0], pa[1],  t],
+            [pb[0], pb[1],  t],
+            [pb[0], pb[1], -t],
+            [pa[0], pa[1], -t],
+        ])
+        norms.extend([[nx, ny, 0]] * 4)
+        tris.append([vi, vi+1, vi+2])
+        tris.append([vi, vi+2, vi+3])
+    return np.array(verts, np.float32), np.array(norms, np.float32), np.array(tris, np.int32)
+
+def _view_rotation(camera):
+    '''Return 3x3 rotation whose columns are camera right / up / -forward
+    expressed in scene coordinates.  This is the TRANSPOSE of the view
+    matrix rotation (view maps scene→camera; we need camera→scene).
+    Screen-fixed overlays use this so they do not rotate with the molecule.'''
+    try:
+        vp = camera.view(camera.position, 0)   # left eye view transform
+        return vp.zero_translation().remove_scale().axes().T.copy()
+    except Exception:
+        return camera.position.zero_translation().remove_scale().axes().T.copy()
+
+def _arrow_view_rotation(R):
+    '''Modify view rotation so arrow cone tip points diagonally into
+    screen (between camera forward and down).  Cone geometry has tip
+    at model -Y, so we remap model Y to point away from the tip.'''
+    import numpy as np
+    from numpy.linalg import norm
+    cam_fwd = -R[:, 2]
+    cam_down = -R[:, 1]
+    tip_dir = cam_fwd + cam_down
+    td_len = norm(tip_dir)
+    tip_dir = tip_dir / td_len if td_len > 0 else cam_fwd
+    y_ax = -tip_dir
+    x_ax = R[:, 0].copy()
+    z_ax = np.cross(x_ax, y_ax)
+    zl = norm(z_ax)
+    if zl > 0:
+        z_ax /= zl
+    x_ax = np.cross(y_ax, z_ax)
+    return np.column_stack([x_ax, y_ax, z_ax])
+
+def _pointer_view_rotation(R):
+    '''Tilt pointer into screen and lean sideways like a real cursor.
+    1) Lean 20° clockwise (tip toward upper-left, classic cursor pose)
+    2) Tilt 25° into screen so the face is partly visible.'''
+    import numpy as np
+    import math
+    from numpy.linalg import norm
+    right = R[:, 0].copy()
+    up = R[:, 1].copy()
+    fwd = -R[:, 2]  # camera forward (into screen)
+    # 1) Lean sideways: rotate around forward axis, clockwise from
+    #    camera POV so tip goes upper-left like a real mouse cursor.
+    lean = math.radians(-20)
+    cl, sl = math.cos(lean), math.sin(lean)
+    right2 = cl * right + sl * up
+    up2 = -sl * right + cl * up
+    # 2) Tilt into screen: rotate around the leaned right axis.
+    tilt = math.radians(25)
+    ct, st = math.cos(tilt), math.sin(tilt)
+    y_ax = ct * up2 + st * fwd
+    x_ax = right2.copy()
+    # Orthonormalise
+    z_ax = np.cross(x_ax, y_ax)
+    zl = norm(z_ax)
+    if zl > 0:
+        z_ax /= zl
+    x_ax = np.cross(y_ax, z_ax)
+    return np.column_stack([x_ax, y_ax, z_ax])
+
+
+class Cursor3D:
+    '''
+    3D cursor for autostereo displays. Renders a small shape in the
+    scene at the depth of whatever is under the mouse, so it appears
+    at the correct stereo depth instead of being flat on the screen.
+    Press C to cycle styles: sphere, crosshair, diamond, arrow, pointer.
+
+    Orientation is baked into vertex positions each frame via
+    set_geometry() so it stays screen-fixed in XR rendering.
+    model.position handles translation only.
+    '''
+    def __init__(self, session, style = 'sphere', radius = 0.4):
+        self._session = session
+        self._radius = radius
+        self._style = style
+        from chimerax.core.models import Surface
+        self._model = m = Surface('3D Cursor', session)
+        m.color = (255, 150, 0, 180)  # Orange, semi-transparent
+        m.pickable = False
+        m.display = False
+        self._apply_style(style)
+        session.models.add([m])
+
+    @property
+    def style(self):
+        return self._style
+
+    def set_style(self, style):
+        self._style = style
+        self._apply_style(style)
+
+    def _apply_style(self, style):
+        import numpy as np
+        r = self._radius
+        if style == 'sphere':
+            from chimerax.surface import sphere_geometry2
+            va, na, ta = sphere_geometry2(80)
+            va = r * va
+        elif style == 'crosshair':
+            va, na, ta = _crosshair_geometry(r)
+        elif style == 'diamond':
+            va, na, ta = _diamond_geometry(r)
+        elif style == 'arrow':
+            va, na, ta = _arrow_geometry(r)
+        elif style == 'pointer':
+            va, na, ta = _pointer_geometry(r * 2.5)
+        else:
+            return
+        # Store base geometry as float64 for precision when rotating.
+        # Rotation is baked into vertices each frame via set_geometry()
+        # rather than using model.position rotation, which gave incorrect
+        # orientation in the XR rendering pipeline.
+        self._base_va = np.array(va, dtype=np.float64)
+        self._base_na = np.array(na, dtype=np.float64)
+        self._base_ta = np.array(ta, dtype=np.int32)
+        self._model.set_geometry(
+            np.array(va, dtype=np.float32),
+            np.array(na, dtype=np.float32),
+            self._base_ta)
+
+    def update(self, x, y):
+        view = self._session.main_view
+        pick = view.picked_object(int(x), int(y))
+        pos = None
+        if pick is not None and hasattr(pick, 'position') and pick.position is not None:
+            pos = pick.position
+            # Offset toward camera so cursor doesn't z-fight with
+            # the surface.
+            cam_origin = view.camera.position.origin()
+            from numpy.linalg import norm
+            to_cam = cam_origin - pos
+            dist = norm(to_cam)
+            if dist > 0:
+                offset = 0.3
+                pos = pos + offset * (to_cam / dist)
+        else:
+            # Nothing under cursor -- place along camera ray at scene
+            # depth, slightly closer to viewer for stereo pop-out.
+            cam = view.camera
+            origin, direction = cam.ray(int(x), int(y), view.window_size)
+            if origin is not None:
+                cofr = view.center_of_rotation
+                from numpy.linalg import norm
+                dist = norm(cofr - cam.position.origin())
+                pos = origin + dist * 0.97 * direction
+
+        if pos is not None:
+            self._place_geometry(pos, view.camera)
+            self._model.display = True
+        else:
+            self._model.display = False
+
+    def _place_geometry(self, pos, camera):
+        '''Place cursor at pos with screen-fixed orientation.
+        Rotation is baked into vertex positions via set_geometry();
+        model.position handles translation only.'''
+        import numpy as np
+        from chimerax.geometry import Place
+        if self._style == 'sphere':
+            va = self._base_va.astype(np.float32)
+            na = self._base_na.astype(np.float32)
+        else:
+            R = _view_rotation(camera)
+            if self._style == 'arrow':
+                R = _arrow_view_rotation(R)
+            elif self._style == 'pointer':
+                R = _pointer_view_rotation(R)
+            va = (R @ self._base_va.T).T.astype(np.float32)
+            na = (R @ self._base_na.T).T.astype(np.float32)
+        self._model.set_geometry(va, na, self._base_ta)
+        self._model.position = Place(origin=pos)
+
+    def hide(self):
+        if self._model is not None:
+            self._model.display = False
+
+    def delete(self):
+        if self._model is not None:
+            self._session.models.remove([self._model])
+            self._model = None
+
+class SelectionRect3D:
+    '''3D selection rectangle for autostereo displays.
+    Renders a semi-transparent quad in the scene at the center-of-rotation
+    depth so the ctrl-drag selection area is visible in stereo.'''
+    def __init__(self, session):
+        self._session = session
+        from chimerax.core.models import Surface
+        self._model = m = Surface('3D Selection', session)
+        m.color = (100, 180, 255, 60)  # Light blue, semi-transparent
+        m.pickable = False
+        m.display = False
+        m.use_lighting = False
+        session.models.add([m])
+
+    def update(self, x0, y0, x1, y1):
+        '''Update rectangle corners from graphics coordinates.'''
+        import numpy as np
+        view = self._session.main_view
+        cam = view.camera
+        cofr = view.center_of_rotation
+        # Plane perpendicular to view direction at center of rotation.
+        # Use camera.view() for the actual rendering view direction
+        # (handles XR room_to_scene scale and rotation correctly).
+        view_dir = -_view_rotation(cam)[:, 2]
+        ws = view.window_size
+        corners_3d = []
+        for cx, cy in [(x0, y0), (x1, y0), (x1, y1), (x0, y1)]:
+            origin, direction = cam.ray(int(cx), int(cy), ws)
+            if origin is None:
+                self._model.display = False
+                return
+            denom = np.dot(direction, view_dir)
+            if abs(denom) < 1e-10:
+                self._model.display = False
+                return
+            t = np.dot(cofr - origin, view_dir) / denom
+            corners_3d.append(origin + t * direction)
+        verts = np.array(corners_3d, dtype=np.float32)
+        norms = np.tile(view_dir.astype(np.float32), (4, 1))
+        # Double-sided quad
+        tris = np.array([
+            [0, 1, 2], [0, 2, 3],
+            [0, 2, 1], [0, 3, 2],
+        ], dtype=np.int32)
+        from chimerax.geometry import identity
+        self._model.position = identity()
+        self._model.set_geometry(verts, norms, tris)
+        self._model.display = True
+
+    def hide(self):
+        if self._model is not None:
+            self._model.display = False
+
+    def delete(self):
+        if self._model is not None:
+            self._session.models.remove([self._model])
+            self._model = None
+
 class XRBackingWindow:
     '''
     Backing window for OpenXR autostereo 3D displays such as Acer SpatialLabs
@@ -166,10 +552,13 @@ class XRBackingWindow:
     mouse is on the 3D display.
     '''
     def __init__(self, session, screen, in_front = False, hover_text = True,
-                 direct_pick = False):
+                 direct_pick = False, cursor_3d = False):
         self._session = session
         self._screen = screen
         self._direct_pick = direct_pick
+        self._cursor = None
+        self._sel_rect = None
+        self._sel_start = None
 
         # Create fullscreen backing Qt window on openxr screen.
         from Qt.QtWidgets import QWidget
@@ -180,11 +569,34 @@ class XRBackingWindow:
 
         w.move(screen.geometry().topLeft())
         w.showFullScreen()
+        w.raise_()
+        w.activateWindow()
+
+        # Hover label state (own pause detection, independent of mouse_modes)
+        self._hover_pos = None
+        self._hover_time = 0
+        self._hover_active = False
+
+        # 3D cursor: hide OS cursor, render a 3D shape at scene depth.
+        # Press C to cycle style: sphere → crosshair → diamond → arrow → pointer.
+        self._cursor_styles = list(_CURSOR_STYLES) if cursor_3d else []
+        self._cursor_style_index = 0
+        if cursor_3d:
+            from Qt.QtCore import Qt
+            w.setCursor(Qt.BlankCursor)
+            w.setMouseTracking(True)
+            self._cursor = Cursor3D(session)
 
         self._register_mouse_handlers()
 
-        # Forward key press events
-        w.keyPressEvent = session.ui.forward_keystroke
+        # Forward key press events, intercepting cursor style toggle
+        def key_press(event):
+            from Qt.QtCore import Qt
+            if self._cursor_styles and event.key() == Qt.Key_C and not event.modifiers():
+                self._cycle_cursor_style()
+            else:
+                session.ui.forward_keystroke(event)
+        w.keyPressEvent = key_press
 
         # Remove backing window when openxr is turned off.
         session.triggers.add_handler('vr stopped', self._xr_quit)
@@ -222,6 +634,14 @@ class XRBackingWindow:
         #  w.setStyleSheet("background:transparent;")
         #  w.setStyleSheet("background:green;")
 
+    def _cycle_cursor_style(self):
+        '''Cycle 3D cursor style: sphere → crosshair → diamond → arrow → pointer.'''
+        self._cursor_style_index = (self._cursor_style_index + 1) % len(self._cursor_styles)
+        style = self._cursor_styles[self._cursor_style_index]
+        if self._cursor is not None:
+            self._cursor.set_style(style)
+        self._session.logger.info(f'3D cursor: {style}')
+
     def _register_mouse_handlers(self):
         w = self._widget
         w.mousePressEvent = self._mouse_down
@@ -231,10 +651,38 @@ class XRBackingWindow:
         w.wheelEvent = self._wheel
 
     def _mouse_down(self, event):
+        # Track ctrl+left drag start for 3D selection rectangle
+        from Qt.QtCore import Qt
+        if event.button() == Qt.LeftButton and event.modifiers() & Qt.ControlModifier:
+            p = event.position()
+            if self._direct_pick:
+                gx, gy = self._backing_to_render_coordinates(p.x(), p.y())
+            else:
+                gx, gy = self._backing_to_graphics_coordinates(p.x(), p.y())
+            self._sel_start = (gx, gy)
+            if self._sel_rect is None:
+                self._sel_rect = SelectionRect3D(self._session)
         self._dispatch_mouse_event(event, "mouse_down")
     def _mouse_drag(self, event):
-        self._dispatch_mouse_event(event, "mouse_drag")
+        # With mouse tracking enabled, mouseMoveEvent fires for all movement.
+        # Only dispatch as drag when a button is actually pressed.
+        if event.buttons():
+            # Update 3D selection rectangle during ctrl+left drag
+            from Qt.QtCore import Qt
+            if self._sel_start is not None and event.buttons() & Qt.LeftButton:
+                p = event.position()
+                if self._direct_pick:
+                    gx, gy = self._backing_to_render_coordinates(p.x(), p.y())
+                else:
+                    gx, gy = self._backing_to_graphics_coordinates(p.x(), p.y())
+                self._sel_rect.update(
+                    self._sel_start[0], self._sel_start[1], gx, gy)
+            self._dispatch_mouse_event(event, "mouse_drag")
     def _mouse_up(self, event):
+        if self._sel_start is not None:
+            self._sel_start = None
+            if self._sel_rect is not None:
+                self._sel_rect.hide()
         self._dispatch_mouse_event(event, "mouse_up")
     def _mouse_double_click(self, event):
         self._dispatch_mouse_event(event, "mouse_double_click")
@@ -331,29 +779,57 @@ class XRBackingWindow:
             raise RuntimeError(f'Event type is not mouse or wheel event {event}')
         return e
 
+    def _graphics_cursor_position(self):
+        from Qt.QtGui import QCursor
+        cp = QCursor.pos()
+        if self._session.ui.topLevelAt(cp) == self._widget:
+            p = self._widget.mapFromGlobal(cp)
+            x,y = self._backing_to_graphics_coordinates(p.x(), p.y())
+            return (int(x), int(y))
+        else:
+            mm = self._session.ui.mouse_modes
+            return mm._graphics_cursor_position_original()
+
     def _check_for_mouse_hover(self, *args):
         if self._widget is None:
             return 'delete handler'
         from Qt.QtGui import QCursor
         cp = QCursor.pos()
         if self._session.ui.topLevelAt(cp) != self._widget:
+            if self._cursor is not None:
+                self._cursor.hide()
             return
 
         bp = self._widget.mapFromGlobal(cp)
-        x,y = self._backing_to_graphics_coordinates(bp.x(), bp.y())
-        mm = self._session.ui.mouse_modes
-        paused, unpaused = mm.mouse_paused((int(x),int(y)))
-        if not paused and not unpaused:
-            return
+        if self._direct_pick:
+            x, y = self._backing_to_render_coordinates(bp.x(), bp.y())
+        else:
+            x, y = self._backing_to_graphics_coordinates(bp.x(), bp.y())
 
-        if paused:
+        # Update 3D cursor position (once per frame, not per mouse event)
+        if self._cursor is not None and self._cursor_styles:
+            self._cursor.update(x, y)
+
+        # Hover labels: detect pause ourselves (mouse_paused doesn't see
+        # our backing window events, so we track position + time directly).
+        import time
+        ix, iy = int(x), int(y)
+        now = time.time()
+        if self._hover_pos != (ix, iy):
+            # Mouse moved — reset timer, hide any active label
+            self._hover_pos = (ix, iy)
+            self._hover_time = now
+            if self._hover_active:
+                self._hover_active = False
+                self._hide_hover_label()
+        elif not self._hover_active and (now - self._hover_time) > 0.7:
+            # Mouse paused for 0.7s — show label
+            self._hover_active = True
             pick, object, label_type = self._hover_pick(x, y)
             if pick is None:
                 self._hide_hover_label()
             else:
                 self._show_hover_label(pick, object, label_type)
-        if unpaused:
-            self._hide_hover_label()
 
     def _show_hover_label(self, pick, object, label_type):
         text = pick.description()
@@ -392,6 +868,12 @@ class XRBackingWindow:
 
     def _xr_quit(self, *args):
         self._hide_hover_label()
+        if self._cursor is not None:
+            self._cursor.delete()
+            self._cursor = None
+        if self._sel_rect is not None:
+            self._sel_rect.delete()
+            self._sel_rect = None
         # Delete the backing window
         self._widget.deleteLater()
         self._widget = None


### PR DESCRIPTION
## Summary

Adds interactive 3D cursor, selection rectangle, and hover labels for autostereo XR displays. On these displays the flat OS mouse cursor doesn't match the stereo depth of the scene, making interaction feel disconnected. This renders a 3D shape at the correct depth under the mouse so it appears at the right stereo position.

## Changes

**xr_screens.py** (all changes are additive, no regressions for existing displays):

- **Cursor3D class**: Renders a 3D shape at the depth of whatever is under the mouse. Tracks mouse position via `picked_object()` and positions the cursor 0.3 angstroms toward the camera to prevent z-fighting. When nothing is under the cursor, it places the shape at center-of-rotation depth along the camera ray.

- **5 cursor styles** (press C to cycle):
  - Sphere: simple 3D sphere
  - Crosshair: three orthogonal thin prisms
  - Diamond: octahedron
  - Arrow: 3D cone pointing diagonally into screen (tip at surface)
  - Pointer: classic mouse cursor shape, tilted into screen for visibility

- **Screen-fixed orientation**: Cursor shapes maintain fixed orientation relative to the screen regardless of molecule rotation. This uses the transpose of the camera view matrix to get camera-to-scene rotation, baked into vertex positions each frame via `set_geometry()`.

- **SelectionRect3D class**: Renders a semi-transparent quad at center-of-rotation depth during ctrl+drag selection, so the selection area is visible in stereo.

- **Hover labels**: Detects mouse pause (0.7s) and shows atom/residue/bond labels in 3D space. Uses its own pause detection since the backing window events don't reach ChimeraX's built-in `mouse_paused` handler.

- Enabled for vrto3d displays via `cursor_3d=True` parameter (Samsung Odyssey 3D). Other displays (Sony, Acer) are unaffected.

## Testing

Tested on Samsung Odyssey 3D G90XF (27" 4K) with vrto3d via SteamVR:

- All 5 cursor styles render correctly in stereo at the right depth
- Cursor stays screen-fixed when rotating/zooming the molecule
- Ctrl+drag selection rectangle visible in 3D
- Hover labels appear after mouse pause on atoms/residues/bonds
- Press C cycles through cursor styles
- `xr off` cleanly removes cursor and selection models
- No regressions for non-cursor displays (Sony, Acer code paths unchanged)