### PR TITLE
mcp_server: bridge fixes for duplicated output, command help, and broader client support

### DIFF
--- a/docs/user/commands/mcp.html
+++ b/docs/user/commands/mcp.html
@@ -70,8 +70,10 @@ Supported hosts and the resulting config files are:
     <a href="https://www.cursor.com/" target="_blank">Cursor</a>
     (global config, applied to every project):
     <ul>
-    <li>on Mac/Linux: ~/.cursor/mcp.json
-    </li><li>on Windows: ~/AppData/Roaming/Cursor/mcp.json
+    <li>on all platforms: ~/.cursor/mcp.json
+    (Cursor's
+    <a href="https://cursor.com/docs/mcp" target="_blank">documentation</a>
+    specifies this same path on Mac, Linux, and Windows)
     </li></ul>
   </li><li><b>vscode</b> &ndash;
     <a href="https://code.visualstudio.com/" target="_blank">VS Code</a>
@@ -124,7 +126,7 @@ request, <i>e.g.</i>, &ldquo;Show me a conotoxin protein in ChimeraX&rdquo;
 <ol>
 <li>Install <a href="https://www.cursor.com/" target="_blank">Cursor</a>
 and run it at least once so that the <code>~/.cursor</code> directory
-(<code>%APPDATA%\Cursor</code> on Windows) is created.
+is created (this is the same path on Mac, Linux, and Windows).
 </li><li>In ChimeraX, run <b>mcp setup host cursor</b>. This writes
 ChimeraX's bridge entry into Cursor's global <code>mcp.json</code>.
 </li><li>Restart Cursor (or use Cursor's "Reload MCP servers" action) and

--- a/docs/user/commands/mcp.html
+++ b/docs/user/commands/mcp.html
@@ -25,7 +25,7 @@ or derivations thereof.
 <a name="stop"></a>
 <a name="info"></a>
 <h3 class="usage"><a href="usageconventions.html">Usage</a>:
-<br><b>mcp setup</b>
+<br><b>mcp setup</b> [&nbsp;<b>host</b>&nbsp;<i>claude</i>&nbsp;|&nbsp;<i>cursor</i>&nbsp;|&nbsp;<i>vscode</i>&nbsp;|&nbsp;<i>all</i>&nbsp;]
 </h3>
 <h3 class="usage"><a href="usageconventions.html">Usage</a>:
 <br><b>mcp start</b> [&nbsp;<i>port</i>&nbsp;]
@@ -37,12 +37,15 @@ or derivations thereof.
 <br><b>mcp stop</b>
 </h3>
 <p>
-The <b>mcp</b> command enables ChimeraX to listen for commands from the 
-<a href="https://www.claude.com/download" target="_blank">Claude Desktop</a>
-AI chatbot using the 
+The <b>mcp</b> command enables ChimeraX to be controlled by an
+MCP-capable AI assistant &mdash; for example
+<a href="https://www.claude.com/download" target="_blank">Claude Desktop</a>,
+<a href="https://www.cursor.com/" target="_blank">Cursor</a>,
+or <a href="https://code.visualstudio.com/" target="_blank">VS Code</a>
+with GitHub Copilot &mdash; using the
 <a href="https://en.wikipedia.org/wiki/Model_Context_Protocol" target="_blank">Model Context Protocol</a> (MCP)
-developed by <a href="https://www.anthropic.com/" target="_blank">Anthropic</a>. 
-Running ChimeraX from Claude was first implemented by Alexis Rohou 
+developed by <a href="https://www.anthropic.com/" target="_blank">Anthropic</a>.
+Running ChimeraX from an AI assistant was first implemented by Alexis Rohou 
 at Genentech and subsequently incorporated 
 into ChimeraX as the <b>mcp</b> command.
 See also: 
@@ -50,23 +53,48 @@ See also:
 <a href="https://www.rbvi.ucsf.edu/chimerax/data/claude-dec2025/claude_mcp.html" target="_blank">Claude Chat to Operate ChimeraX</a>
 </p>
 <ul>
-<li><b>mcp setup</b>
-&ndash; write a
-<a href="https://www.claude.com/download" target="_blank">Claude Desktop</a>
-configuration file to allow it to control ChimeraX using MCP; 
-this only needs to be done once per computer and ChimeraX version.
-The configuration file name and location depend on the platform:
+<li><b>mcp setup</b> [&nbsp;<b>host</b>&nbsp;<i>host-name</i>&nbsp;]
+&ndash; write a configuration file telling an MCP-capable AI assistant
+how to launch the ChimeraX MCP bridge.
+The optional <b>host</b> keyword selects which assistant to configure;
+this only needs to be done once per host per ChimeraX version.
+Supported hosts and the resulting config files are:
   <ul>
-  <li>on Mac: ~/Library/Application Support/Claude/claude_desktop_config.json
-  </li><li>on Windows: ~/AppData/Roaming/Claude/claude_desktop_config.json
+  <li><b>claude</b> (default) &ndash;
+    <a href="https://www.claude.com/download" target="_blank">Claude Desktop</a>:
+    <ul>
+    <li>on Mac: ~/Library/Application Support/Claude/claude_desktop_config.json
+    </li><li>on Windows: ~/AppData/Roaming/Claude/claude_desktop_config.json
+    </li></ul>
+  </li><li><b>cursor</b> &ndash;
+    <a href="https://www.cursor.com/" target="_blank">Cursor</a>
+    (global config, applied to every project):
+    <ul>
+    <li>on Mac/Linux: ~/.cursor/mcp.json
+    </li><li>on Windows: ~/AppData/Roaming/Cursor/mcp.json
+    </li></ul>
+  </li><li><b>vscode</b> &ndash;
+    <a href="https://code.visualstudio.com/" target="_blank">VS Code</a>
+    with
+    <a href="https://code.visualstudio.com/docs/copilot/customization/mcp-servers" target="_blank">GitHub Copilot MCP servers</a>
+    (user-profile config, applied to every workspace):
+    <ul>
+    <li>on Mac: ~/Library/Application Support/Code/User/mcp.json
+    </li><li>on Linux: ~/.config/Code/User/mcp.json
+    </li><li>on Windows: ~/AppData/Roaming/Code/User/mcp.json
+    </li></ul>
+  </li><li><b>all</b> &ndash; configure every supported host whose config
+    directory is present on this machine.
   </li></ul>
 </li><li><b>mcp start</b> [&nbsp;<i>port</i>&nbsp;]
 &ndash; start the ChimeraX REST server for MCP bridge connections using 
 port number <i>port</i> (default <b>8080</b>);
-this is not required if ChimeraX is started by Claude
+this is not required if the AI assistant launches ChimeraX itself.
 </li><li><b>mcp info</b>
-&ndash; check to see if ChimeraX is listening for commands 
-via REST server on localhost port 8080
+&ndash; for each supported host, report whether it is configured to use
+this ChimeraX. Also report whether the ChimeraX REST server is currently
+running and, if so, on which port and whether JSON output and logging
+(both required by the MCP bridge) are enabled.
 </li><li><b>mcp stop</b>
 &ndash; stop the ChimeraX REST server
 </li></ul>
@@ -90,6 +118,33 @@ button leaves hidden Claude subprocesses running that will prevent it from
 reading the configuration file when restarted.
 </li><li>Restart Claude Desktop and test by giving Claude a natural language 
 request, <i>e.g.</i>, &ldquo;Show me a conotoxin protein in ChimeraX&rdquo;
+</li></ol>
+
+<h3>Set Up Cursor to Control ChimeraX</h3>
+<ol>
+<li>Install <a href="https://www.cursor.com/" target="_blank">Cursor</a>
+and run it at least once so that the <code>~/.cursor</code> directory
+(<code>%APPDATA%\Cursor</code> on Windows) is created.
+</li><li>In ChimeraX, run <b>mcp setup host cursor</b>. This writes
+ChimeraX's bridge entry into Cursor's global <code>mcp.json</code>.
+</li><li>Restart Cursor (or use Cursor's "Reload MCP servers" action) and
+ask the chat to perform a ChimeraX action.
+</li></ol>
+
+<h3>Set Up VS Code Copilot to Control ChimeraX</h3>
+<ol>
+<li>Install <a href="https://code.visualstudio.com/" target="_blank">VS Code</a>
+with
+<a href="https://code.visualstudio.com/docs/copilot/customization/mcp-servers" target="_blank">GitHub Copilot</a>
+and ensure MCP support is enabled.
+</li><li>In ChimeraX, run <b>mcp setup host vscode</b>. This writes
+ChimeraX's bridge entry into the user-profile
+<code>mcp.json</code> in the form expected by VS Code (top-level
+<code>servers</code> key, with <code>"type": "stdio"</code>).
+</li><li>In VS Code, run the command palette action
+<b>MCP: List Servers</b> to verify that the <code>chimerax</code>
+server is listed, then start it from there or simply ask Copilot to
+perform a ChimeraX action.
 </li></ol>
 
 <hr>

--- a/docs/user/index.html
+++ b/docs/user/index.html
@@ -354,9 +354,8 @@ and shadowing</li>
 <li><a href="commands/mcopy.html"><b>mcopy</b></a>
 &ndash; copy settings from one atomic model to another</li>
 <li><a href="commands/mcp.html"><b>mcp</b></a>
-&ndash; enable ChimeraX to listen for commands from 
-<a href="https://www.claude.com/download" target="_blank">Claude Desktop</a>
-AI</li>
+&ndash; enable ChimeraX to be controlled by an MCP-capable AI assistant
+(Claude Desktop, Cursor, VS Code Copilot, ...)</li>
 <li><a href="commands/measure.html"><b>measure</b></a>
 &ndash; measure surface area, enclosed volume, center, path length, 
 map statistics, <i>etc.</i></li>

--- a/src/bundles/mcp_server/pyproject.toml
+++ b/src/bundles/mcp_server/pyproject.toml
@@ -16,8 +16,9 @@ dynamic = ["classifiers", "requires-python", "version"]
 [project.readme]
 content-type = "text"
 text = """The MCP Server bundle provides Model Context Protocol (MCP) functionality
-for ChimeraX, enabling external applications like Claude Code to communicate
-with and control ChimeraX programmatically."""
+for ChimeraX, enabling MCP-capable AI assistants (Claude Desktop, Cursor,
+VS Code Copilot, etc.) to communicate with and control ChimeraX
+programmatically."""
 
 [project.urls]
 Home = "https://www.rbvi.ucsf.edu/chimerax/"
@@ -33,7 +34,7 @@ classifiers = ["Development Status :: 2 - Pre-Alpha"]
 
 [tool.chimerax.command."mcp start"]
 category = "General"
-description = "Start the REST to allow Claude to control ChimeraX"
+description = "Start the REST server so an MCP-capable AI assistant can control ChimeraX"
 
 [tool.chimerax.command."mcp stop"]
 category = "General"
@@ -41,8 +42,8 @@ description = "Stop the REST server"
 
 [tool.chimerax.command."mcp info"]
 category = "General"
-description = "Report if Claude is configured to control ChimeraX and if the REST server is running"
+description = "Report which AI assistants are configured to control ChimeraX and whether the REST server is running"
 
 [tool.chimerax.command."mcp setup"]
 category = "General"
-description = "Write the Claude Desktop configuration file to allow it to control ChimeraX"
+description = "Write a configuration file for an MCP-capable AI assistant (Claude Desktop, Cursor, VS Code Copilot) so it can control ChimeraX"

--- a/src/bundles/mcp_server/src/chimerax_mcp_bridge.py
+++ b/src/bundles/mcp_server/src/chimerax_mcp_bridge.py
@@ -52,6 +52,7 @@ Session Management Behavior:
 
 import logging
 import os
+import re
 import sys
 import asyncio
 import aiohttp
@@ -554,7 +555,48 @@ async def run_chimerax_command(command: str, port: Optional[int] = None) -> dict
             raise
         raise Exception(f"Error communicating with ChimeraX: {e}")
 
-def format_chimerax_response(result: dict, context: str = "") -> str:
+_CXCMD_LINK_RE = re.compile(r'^\[.+?\]\(cxcmd:.+?\)$')
+_LEADING_SEMICOLON_RE = re.compile(r'^\s*;\s*')
+_BLANK_LINE_RUN_RE = re.compile(r'\n{3,}')
+
+
+def _clean_log_message(msg: str, command: Optional[str]) -> Optional[str]:
+    """Clean a single ChimeraX log message, returning None if it should be dropped.
+
+    Drops:
+    - empty / whitespace-only messages
+    - clickable command echoes like `[cmd](cxcmd:cmd)` (single-link form)
+    - markdown-link-heavy messages (>=2 markdown links starting with `[`)
+    - plain-text echoes equal to the command we just executed
+
+    Cleans:
+    - strips a leading `;` / `; ` continuation marker that ChimeraX inserts
+      when concatenating log lines.
+    """
+    msg_stripped = msg.strip()
+    if not msg_stripped:
+        return None
+
+    # Drop the clickable command echo `[cmd](cxcmd:cmd)` (single-link form).
+    if _CXCMD_LINK_RE.match(msg_stripped):
+        return None
+
+    # Drop markdown-link-heavy command echoes (legacy filter, multi-link form).
+    if msg_stripped.startswith('[') and msg_stripped.count('](') >= 2:
+        return None
+
+    # Drop plain-text echoes of the command itself.
+    if command and msg_stripped == command.strip():
+        return None
+
+    # Strip leading "; " continuation marker.
+    cleaned = _LEADING_SEMICOLON_RE.sub('', msg)
+    if not cleaned.strip():
+        return None
+    return cleaned
+
+
+def format_chimerax_response(result: dict, context: str = "", command: Optional[str] = None) -> str:
     """Format structured ChimeraX response into readable string
     
     Implements a cascading fallback strategy:
@@ -565,6 +607,8 @@ def format_chimerax_response(result: dict, context: str = "") -> str:
     Args:
         result: Dict with 'return_values', 'json_values', and 'logs' keys
         context: Optional context string to prepend to output
+        command: Optional command string that was executed; used to drop
+            ChimeraX's own command-echo log lines from the output.
     
     Returns:
         Formatted string with context and log messages/return values organized by level
@@ -583,15 +627,11 @@ def format_chimerax_response(result: dict, context: str = "") -> str:
     for level in ["error", "warning", "info", "note", "debug"]:
         messages = logs.get(level, [])
         if messages:
-            # Filter out empty messages and markdown-heavy command echoes
             filtered_messages = []
             for msg in messages:
-                if msg.strip():
-                    # Skip messages that are primarily markdown links (command echoes)
-                    # These typically start with markdown link syntax and contain multiple links
-                    msg_stripped = msg.strip()
-                    if not (msg_stripped.startswith('[') and msg_stripped.count('](') >= 2):
-                        filtered_messages.append(msg)
+                cleaned = _clean_log_message(msg, command)
+                if cleaned is not None:
+                    filtered_messages.append(cleaned)
             if filtered_messages:
                 output.append(f"{level.upper()}: {'; '.join(filtered_messages)}")
                 has_log_content = True
@@ -634,7 +674,10 @@ def format_chimerax_response(result: dict, context: str = "") -> str:
     elif not output:  # Nothing at all
         return "Command completed successfully"
     
-    return "\n".join(output)
+    joined = "\n".join(output)
+    # Collapse runs of >=3 newlines (which arise when individual log messages
+    # already contain trailing blank lines) down to a single blank line.
+    return _BLANK_LINE_RUN_RE.sub("\n\n", joined).strip()
 
 def add_error_hints(error_type: str, error_msg: str, command: str) -> str:
     """Add contextual hints to ChimeraX error messages to guide agents.

--- a/src/bundles/mcp_server/src/chimerax_mcp_bridge.py
+++ b/src/bundles/mcp_server/src/chimerax_mcp_bridge.py
@@ -1060,10 +1060,9 @@ async def run_command(command: str, session_id: Optional[int] = None) -> str:
     '''
 
     result = await run_chimerax_command(command, session_id)
-    session_info = f" on session {session_id}" if session_id else ""
-    context = f"Command executed{session_info}: {command}"
+    context = f"[session {session_id}]" if session_id else ""
     
-    return format_chimerax_response(result, context)
+    return format_chimerax_response(result, context, command=command)
 
 #@mcp.tool(structured_output=False)
 async def open_structure(identifier: str, format: str = "auto-detect", fetch_emdb_map: bool = False, session_id: Optional[int] = None) -> str:
@@ -1098,12 +1097,9 @@ async def open_structure(identifier: str, format: str = "auto-detect", fetch_emd
         command += " fetchEmdbMap true"
 
     result = await run_chimerax_command(command, session_id)
-    session_info = f" in session {session_id}" if session_id else ""
-    context = f"Opened structure: {identifier}{session_info}"
-    if fetch_emdb_map:
-        context += " (with EMDB map)"
+    context = f"[session {session_id}]" if session_id else ""
     
-    return format_chimerax_response(result, context)
+    return format_chimerax_response(result, context, command=command)
 
 def _format_single_model_info(model: dict) -> list:
     """Helper function to format a single model's information into lines of text.
@@ -1272,13 +1268,13 @@ async def list_models(session_id: Optional[int] = None) -> str:
             output.extend(model_lines)
         
         context = "\n".join(output)
-        return format_chimerax_response(result, context)
+        return format_chimerax_response(result, context, command="info")
     else:
         output = [f"Models{session_info}:"]
         output.append("No models loaded")
         
         context = "\n".join(output)
-        return format_chimerax_response(result, context)
+        return format_chimerax_response(result, context, command="info")
 
 @mcp.tool(structured_output=False)
 async def get_shown(session_id: Optional[int] = None) -> str:
@@ -1576,10 +1572,9 @@ async def color_models(color: str, target: str = "all", session_id: Optional[int
     """
     command = f"color {target} {color}"
     result = await run_chimerax_command(command, session_id)
-    session_info = f" in session {session_id}" if session_id else ""
-    context = f"Colored {target} with {color}{session_info}"
+    context = f"[session {session_id}]" if session_id else ""
     
-    return format_chimerax_response(result, context)
+    return format_chimerax_response(result, context, command=command)
 
 # @mcp.tool(structured_output=False)
 async def save_image(filename: str, width: int = 1920, height: int = 1080, supersample: int = 3, session_id: Optional[int] = None) -> str:
@@ -1596,10 +1591,9 @@ async def save_image(filename: str, width: int = 1920, height: int = 1080, super
     """
     command = f"save {filename} width {width} height {height} supersample {supersample}"
     result = await run_chimerax_command(command, session_id)
-    session_info = f" from session {session_id}" if session_id else ""
-    context = f"Saved image: {filename}{session_info} ({width}x{height}, supersample {supersample})"
+    context = f"[session {session_id}]" if session_id else ""
     
-    return format_chimerax_response(result, context)
+    return format_chimerax_response(result, context, command=command)
 
 
 @mcp.tool(structured_output=False)
@@ -1940,13 +1934,14 @@ async def get_command_documentation(command: str) -> str:
         if " " not in stripped:
             return html_doc
 
+    usage_command = f"usage {stripped}"
     try:
-        result = await run_chimerax_command(f"usage {stripped}")
+        result = await run_chimerax_command(usage_command)
     except Exception as e:
         if html_doc.startswith("No documentation found") or html_doc.startswith("Documentation not found"):
             return f"No documentation found for command: {command} (usage fallback also failed: {e})"
         return html_doc
-    return format_chimerax_response(result, context=f"# ChimeraX Command: {stripped}\n")
+    return format_chimerax_response(result, context=f"# ChimeraX Command: {stripped}\n", command=usage_command)
 
 # Cleanup function for aiohttp session
 async def cleanup():

--- a/src/bundles/mcp_server/src/chimerax_mcp_bridge.py
+++ b/src/bundles/mcp_server/src/chimerax_mcp_bridge.py
@@ -754,6 +754,19 @@ def add_error_hints(error_type: str, error_msg: str, command: str) -> str:
         hints.append("→ Check that you've included all required arguments")
         hints.append("→ Verify keyword spelling and order")
     
+    # ===== Hierarchical (Incomplete) Command =====
+    # Real ChimeraX error: "Incomplete command: <prefix>" raised by cli when a command
+    # is a category with sub-actions (e.g. `isolde validate`, `clipper`, `volume`) and
+    # the user supplied only the prefix without picking a sub-action.
+    elif "incomplete command" in error_lower:
+        cmd_parts = command.strip().split()
+        root_cmd = cmd_parts[0] if cmd_parts else "unknown"
+        full_cmd = command.strip() or root_cmd
+        
+        hints.append(f"\n\n🔍 HINT: '{full_cmd}' is incomplete — '{root_cmd}' is a hierarchical command with sub-actions.")
+        hints.append(f"→ Run `help {full_cmd}` via run_command to see the available sub-actions and their arguments.")
+        hints.append(f"→ Then re-run with the full sub-command, e.g. {full_cmd} <subaction> [args].")
+    
     # ===== File/Path Errors =====
     elif any(pattern in error_lower for pattern in [
         "cannot open",

--- a/src/bundles/mcp_server/src/chimerax_mcp_bridge.py
+++ b/src/bundles/mcp_server/src/chimerax_mcp_bridge.py
@@ -993,7 +993,7 @@ async def run_command(command: str, session_id: Optional[int] = None) -> str:
     - Common atomspecs: #1 (model), #1/A (chain), #1/A:100 (residue), @ca (atom type), HC (nonpolar hydrogens), #1/A & ligand (ligands in chain A of model 1), `ligand | (ligand :< 5)` (ligand and residues within 5 Å of ligand), `#1/A:100 :< 6` (residues within 6 Å of residue 100 in chain A of model 1)
     
     To see a list of all commands, use the list_commands() tool.
-    For command syntax help, use get_command_documentation(command_name).
+    For command syntax help, use get_command_documentation(command).
 
     Frequently-used commands:
     - volume #2 step 1 sdLevel 5.0 transparency 0.5 - display map #2 with step size 1, surface level 5.0 standard deviations (sigma), transparency 50%
@@ -1869,19 +1869,41 @@ async def list_chimerax_commands() -> str:
             break
 
     result += f"\nTotal: {len(commands)} commands available\n"
-    result += "Use get_command_documentation(command_name) to get detailed documentation for any command."
+    result += "Use get_command_documentation(command) to get detailed documentation for any command."
     return result
 
 @mcp.tool()
-async def get_command_documentation(command_name: str) -> str:
+async def get_command_documentation(command: str) -> str:
     """Get detailed documentation for a specific ChimeraX command.
     
-    Use this to learn the correct syntax, arguments, and usage for a specific command.
+    Tries the local HTML reference docs first (rich output for core commands like
+    `open`, `color`, etc.), then falls back to running `usage <command>` against
+    the live ChimeraX session. The fallback works for bundle-provided commands
+    (e.g. `isolde`) and hierarchical sub-paths (e.g. `isolde validate`).
     
     Args:
-        command_name: Name of the ChimeraX command (e.g., 'open', 'color', 'save')
+        command: Name of the ChimeraX command (e.g., 'open', 'color',
+            'isolde', 'isolde validate'). Multi-word inputs are supported and
+            preferred for hierarchical commands, since their sub-actions only
+            show up in the live `usage` output.
     """
-    return get_command_doc(command_name)
+    stripped = command.strip()
+    if not stripped:
+        return "No command specified."
+
+    root = stripped.split()[0]
+    html_doc = get_command_doc(root)
+    if not html_doc.startswith("No documentation found") and not html_doc.startswith("Documentation not found"):
+        if " " not in stripped:
+            return html_doc
+
+    try:
+        result = await run_chimerax_command(f"usage {stripped}")
+    except Exception as e:
+        if html_doc.startswith("No documentation found") or html_doc.startswith("Documentation not found"):
+            return f"No documentation found for command: {command} (usage fallback also failed: {e})"
+        return html_doc
+    return format_chimerax_response(result, context=f"# ChimeraX Command: {stripped}\n")
 
 # Cleanup function for aiohttp session
 async def cleanup():

--- a/src/bundles/mcp_server/src/chimerax_mcp_bridge.py
+++ b/src/bundles/mcp_server/src/chimerax_mcp_bridge.py
@@ -3,7 +3,9 @@
 """
 ChimeraX MCP Bridge (Python)
 
-This bridges Claude (via MCP protocol) to ChimeraX REST servers.
+Bridges any MCP-capable AI assistant (Claude Desktop, Cursor, VS Code
+Copilot, Claude Code, etc.) to one or more ChimeraX REST servers using
+the Model Context Protocol (MCP).
 Uses the official MCP Python SDK for robust protocol handling.
 Supports M-to-N architecture: multiple agents controlling multiple ChimeraX instances.
 
@@ -18,8 +20,13 @@ Prerequisites:
 1. Install the ChimeraX MCP server bundle in ChimeraX
 2. ChimeraX will be auto-started when needed
 
-Usage with Claude Desktop:
-Add to your claude_desktop_config.json:
+The recommended way to register this bridge with a host is the ChimeraX
+command `mcp setup [host claude|cursor|vscode|all]`, which writes the
+correct config file for that host. The configurations below are shown
+for reference.
+
+Example client configuration (Claude Desktop's claude_desktop_config.json,
+or Cursor's mcp.json):
 {
   "mcpServers": {
     "chimerax": {
@@ -29,6 +36,19 @@ Add to your claude_desktop_config.json:
         "CHIMERAX_REST_HOST": "localhost",
         "CHIMERAX_REST_PORT": "8080"
       }
+    }
+  }
+}
+
+For VS Code Copilot the equivalent file is .vscode/mcp.json (workspace)
+or the user-profile mcp.json. Its schema uses the top-level "servers"
+key and requires "type": "stdio" on each entry:
+{
+  "servers": {
+    "chimerax": {
+      "type": "stdio",
+      "command": "python",
+      "args": ["/path/to/chimerax_mcp_bridge.py"]
     }
   }
 }

--- a/src/bundles/mcp_server/src/chimerax_mcp_bridge.py
+++ b/src/bundles/mcp_server/src/chimerax_mcp_bridge.py
@@ -794,7 +794,7 @@ def add_error_hints(error_type: str, error_msg: str, command: str) -> str:
     
     return full_error
 
-@mcp.tool()
+@mcp.tool(structured_output=False)
 async def get_atomspec_guide() -> str:
     """Get the complete guide for ChimeraX atomspec (object specification) syntax.
     
@@ -983,7 +983,7 @@ aromatic-ring & :phe,tyr  # Aromatic ring carbons in Phe and Tyr
 For more details, see: https://www.cgl.ucsf.edu/chimerax/docs/user/commands/atomspec.html
     """
 
-@mcp.tool()
+@mcp.tool(structured_output=False)
 async def run_command(command: str, session_id: Optional[int] = None) -> str:
     """Execute any ChimeraX command directly. Use this tool if you don't find another tool
     that suits your needs.
@@ -1022,7 +1022,7 @@ async def run_command(command: str, session_id: Optional[int] = None) -> str:
     
     return format_chimerax_response(result, context)
 
-#@mcp.tool()
+#@mcp.tool(structured_output=False)
 async def open_structure(identifier: str, format: str = "auto-detect", fetch_emdb_map: bool = False, session_id: Optional[int] = None) -> str:
     """Open a molecular structure file or fetch from PDB
 
@@ -1160,7 +1160,7 @@ def _format_single_model_info(model: dict) -> list:
     
     return output
 
-@mcp.tool()
+@mcp.tool(structured_output=False)
 async def list_models(session_id: Optional[int] = None) -> str:
     """List all models currently loaded in ChimeraX with key details.
 
@@ -1237,7 +1237,7 @@ async def list_models(session_id: Optional[int] = None) -> str:
         context = "\n".join(output)
         return format_chimerax_response(result, context)
 
-@mcp.tool()
+@mcp.tool(structured_output=False)
 async def get_shown(session_id: Optional[int] = None) -> str:
     """Get information about what is currently shown.
         
@@ -1320,7 +1320,7 @@ async def get_shown(session_id: Optional[int] = None) -> str:
         return '{"models": []}'
 
 
-@mcp.tool()
+@mcp.tool(structured_output=False)
 async def get_model_info(model_id: str, session_id: Optional[int] = None) -> str:
     """Get detailed information about a specific model, including details about
     all its chains. You can call this to get all chain identifications in one go.
@@ -1492,7 +1492,7 @@ async def _get_chain_info_helper(model_id: str, chain_id: str, session_id: Optio
     
     return output, combined_result
 
-@mcp.tool()
+@mcp.tool(structured_output=False)
 async def get_chain_info(model_id: str, chain_id: str, session_id: Optional[int] = None) -> str:
     """Get detailed information about a specific chain in a model
     
@@ -1515,7 +1515,7 @@ async def get_chain_info(model_id: str, chain_id: str, session_id: Optional[int]
     return format_chimerax_response(result, context)
 
 
-@mcp.tool()
+@mcp.tool(structured_output=False)
 async def color_models(color: str, target: str = "all", session_id: Optional[int] = None) -> str:
     """Color models or parts of models
     
@@ -1538,7 +1538,7 @@ async def color_models(color: str, target: str = "all", session_id: Optional[int
     
     return format_chimerax_response(result, context)
 
-# @mcp.tool()
+# @mcp.tool(structured_output=False)
 async def save_image(filename: str, width: int = 1920, height: int = 1080, supersample: int = 3, session_id: Optional[int] = None) -> str:
     """Save a screenshot of the current view
 
@@ -1559,7 +1559,7 @@ async def save_image(filename: str, width: int = 1920, height: int = 1080, super
     return format_chimerax_response(result, context)
 
 
-@mcp.tool()
+@mcp.tool(structured_output=False)
 async def superpose_residue(
     source_model: str,
     source_chain: str,
@@ -1624,7 +1624,7 @@ async def superpose_residue(
     
     return format_chimerax_response(combined_result, context)
 
-# @mcp.tool()
+# @mcp.tool(structured_output=False)
 async def show_hide_objects(
     action: str,
     atomspec: str,
@@ -1744,7 +1744,7 @@ async def show_hide_objects(
 
 # Instance management tools
 
-@mcp.tool()
+@mcp.tool(structured_output=False)
 async def list_chimerax_instances() -> str:
     """List all running ChimeraX instances"""
     instances = await list_running_instances()
@@ -1760,7 +1760,7 @@ async def list_chimerax_instances() -> str:
 
     return result
 
-@mcp.tool()
+@mcp.tool(structured_output=False)
 async def start_new_chimerax_session(session_name: Optional[str] = None, port: Optional[int] = None) -> str:
     """Start a new ChimeraX instance/session
 
@@ -1806,7 +1806,7 @@ async def start_new_chimerax_session(session_name: Optional[str] = None, port: O
     else:
         return f"Failed to start ChimeraX session on port {port}"
 
-@mcp.tool()
+@mcp.tool(structured_output=False)
 async def check_chimerax_status(session_id: Optional[int] = None) -> str:
     """Check if ChimeraX is running and accessible
 
@@ -1829,7 +1829,7 @@ async def check_chimerax_status(session_id: Optional[int] = None) -> str:
         else:
             return f"ChimeraX is not running on port {port} and executable not found in common locations."
 
-@mcp.tool()
+@mcp.tool(structured_output=False)
 async def set_default_session(session_id: int) -> str:
     """Set the default ChimeraX session for commands without explicit session_id
 
@@ -1850,7 +1850,7 @@ async def set_default_session(session_id: int) -> str:
 
     return f"Default session changed from port {old_default} to port {session_id} ({session_name})"
 
-@mcp.tool()
+@mcp.tool(structured_output=False)
 async def list_chimerax_commands() -> str:
     """List all available ChimeraX commands.
     
@@ -1872,7 +1872,7 @@ async def list_chimerax_commands() -> str:
     result += "Use get_command_documentation(command) to get detailed documentation for any command."
     return result
 
-@mcp.tool()
+@mcp.tool(structured_output=False)
 async def get_command_documentation(command: str) -> str:
     """Get detailed documentation for a specific ChimeraX command.
     

--- a/src/bundles/mcp_server/src/chimerax_mcp_bridge.py
+++ b/src/bundles/mcp_server/src/chimerax_mcp_bridge.py
@@ -50,6 +50,7 @@ Session Management Behavior:
 5. check_chimerax_status() only checks, never starts ChimeraX
 """
 
+import logging
 import os
 import sys
 import asyncio
@@ -61,12 +62,11 @@ import time
 import platform
 from typing import Optional
 
+logger = logging.getLogger("chimerax-bridge")
+
 # ChimeraX connection settings
 CHIMERAX_HOST = 'localhost'
 DEFAULT_CHIMERAX_PORT = 8080
-
-# Debug settings
-DEBUG = False  # Set to True to enable debug logging to /tmp/
 
 # Global state for managing multiple ChimeraX instances
 _instances = {}  # port -> instance info
@@ -233,10 +233,10 @@ async def check_existing_rest_server() -> tuple[bool, int]:
                             port_match = re.search(r'port (\d+)', result)
                             if port_match:
                                 rest_port = int(port_match.group(1))
-                                print(f"Found existing REST server on port {rest_port}", file=sys.stderr)
+                                logger.info("Found existing REST server on port %d", rest_port)
                                 return True, rest_port
                         elif "not running" in result:
-                            print(f"ChimeraX on port {check_port} has no REST server running", file=sys.stderr)
+                            logger.info("ChimeraX on port %d has no REST server running", check_port)
                             return False, check_port
             except:
                 continue
@@ -260,12 +260,12 @@ async def start_chimerax(port: Optional[int] = None, session_name: Optional[str]
     if not force_new and port == _default_port:
         has_rest, existing_port = await check_existing_rest_server()
         if has_rest:
-            print(f"Using existing ChimeraX REST server on port {existing_port} (default port: {_default_port})", file=sys.stderr)
+            logger.info("Using existing ChimeraX REST server on port %d (default port: %d)", existing_port, _default_port)
             return True, existing_port
 
     # Check if already running on this port
     if await is_chimerax_running(port):
-        print(f"ChimeraX is already running on port {port}", file=sys.stderr)
+        logger.info("ChimeraX is already running on port %d", port)
         return True, port
 
     # If port is taken but not by ChimeraX, find a new one
@@ -279,11 +279,11 @@ async def start_chimerax(port: Optional[int] = None, session_name: Optional[str]
 
     chimerax_path = find_chimerax_executable()
     if not chimerax_path:
-        print("ChimeraX executable not found. Please install ChimeraX or add it to PATH.", file=sys.stderr)
+        logger.error("ChimeraX executable not found. Please install ChimeraX or add it to PATH.")
         return False, port
 
     try:
-        print(f"Starting ChimeraX from {chimerax_path} on port {port}...", file=sys.stderr)
+        logger.info("Starting ChimeraX from %s on port %d...", chimerax_path, port)
 
         if platform.system() == "Windows":
             # Windows doesn't have fork, use subprocess with DETACHED_PROCESS
@@ -293,7 +293,7 @@ async def start_chimerax(port: Optional[int] = None, session_name: Optional[str]
         else:
             # Unix-like systems: use double-fork
             if not start_chimerax_daemon(port):
-                print("Failed to start ChimeraX daemon", file=sys.stderr)
+                logger.error("Failed to start ChimeraX daemon")
                 return False, port
 
         # Register the instance
@@ -308,16 +308,16 @@ async def start_chimerax(port: Optional[int] = None, session_name: Optional[str]
         for _ in range(30):
             await asyncio.sleep(1)
             if await is_chimerax_running(port):
-                print(f"ChimeraX started successfully on port {port}!", file=sys.stderr)
+                logger.info("ChimeraX started successfully on port %d!", port)
                 _instances[port]["status"] = "running"
                 return True, port
 
-        print("Timeout waiting for ChimeraX to start", file=sys.stderr)
+        logger.error("Timeout waiting for ChimeraX to start")
         _instances[port]["status"] = "failed"
         return False, port
 
     except Exception as e:
-        print(f"Failed to start ChimeraX: {e}", file=sys.stderr)
+        logger.error("Failed to start ChimeraX: %s", e)
         if port in _instances:
             _instances[port]["status"] = "failed"
         return False, port
@@ -444,7 +444,7 @@ async def find_best_chimerax_instance() -> int:
 
     # First check if default port is running
     if await is_chimerax_running(_default_port):
-        print(f"Using default ChimeraX instance on port {_default_port}", file=sys.stderr)
+        logger.info("Using default ChimeraX instance on port %d", _default_port)
         return _default_port
 
     # Quick scan for any running ChimeraX instances (common ports only)
@@ -456,12 +456,13 @@ async def find_best_chimerax_instance() -> int:
 
         if await is_chimerax_running(port):
             # Found one! But DON'T change the default - just use it for this operation
-            print(f"WARNING: Found ChimeraX instance on port {port}, but default is still {_default_port}. "
-                  f"Use set_default_session({port}) if you want to make this the default.", file=sys.stderr)
+            logger.warning("Found ChimeraX instance on port %d, but default is still %d. "
+                          "Use set_default_session(%d) if you want to make this the default.",
+                          port, _default_port, port)
             return port
 
     # No instances found, return default port (will trigger auto-start)
-    print(f"No ChimeraX instances found, will try to start on port {_default_port}", file=sys.stderr)
+    logger.info("No ChimeraX instances found, will try to start on port %d", _default_port)
     return _default_port
 
 async def _execute_command_request(session, url: str, command: str) -> dict:
@@ -485,22 +486,11 @@ async def _execute_command_request(session, url: str, command: str) -> dict:
             # Parse JSON response
             data = await response.json()
             
-            # DEBUG: Write full response to file
-            if DEBUG:
-                import json
-                import time
-                debug_file = f"/tmp/chimerax_response_{int(time.time() * 1000)}.json"
-                try:
-                    with open(debug_file, 'w') as f:
-                        json.dump({
-                            "command": command,
-                            "url": url,
-                            "raw_response": data
-                        }, f, indent=2)
-                    print(f"DEBUG: Full response written to {debug_file}", file=sys.stderr)
-                except Exception as e:
-                    print(f"DEBUG: Failed to write debug file: {e}", file=sys.stderr)
-            
+            if logger.isEnabledFor(logging.DEBUG):
+                import json as _json
+                logger.debug("Response for %r (url=%s): %s",
+                             command, url, _json.dumps(data, indent=2))
+
             # Check for errors - raise exception if present
             if data.get("error") is not None:
                 error_info = data["error"]
@@ -1773,7 +1763,7 @@ async def start_new_chimerax_session(session_name: Optional[str] = None, port: O
     if port is None:
         # Find an available port, starting from the default
         port = find_available_port(_default_port)
-        print(f"No port specified, found available port: {port}", file=sys.stderr)
+        logger.info("No port specified, found available port: %d", port)
 
     # Check if already running on this port
     if await is_chimerax_running(port):
@@ -1788,7 +1778,7 @@ async def start_new_chimerax_session(session_name: Optional[str] = None, port: O
         return f"ChimeraX is already running on port {port} (session: {existing_session}). To start a new session, use port {available_port} instead."
 
     # Force a new instance - always use force_new=True to avoid reusing existing instances
-    print(f"Starting new ChimeraX instance on port {port} (force_new=True)", file=sys.stderr)
+    logger.info("Starting new ChimeraX instance on port %d (force_new=True)", port)
     success, actual_port = await start_chimerax(port, session_name, force_new=True)
     if success:
         # Use the requested session name, or get from instances if not provided

--- a/src/bundles/mcp_server/src/chimerax_mcp_bridge.py
+++ b/src/bundles/mcp_server/src/chimerax_mcp_bridge.py
@@ -633,7 +633,14 @@ def format_chimerax_response(result: dict, context: str = "", command: Optional[
                 if cleaned is not None:
                     filtered_messages.append(cleaned)
             if filtered_messages:
-                output.append(f"{level.upper()}: {'; '.join(filtered_messages)}")
+                # Use '\n\n' (not '; ') as the separator: many ChimeraX log
+                # messages are multi-line markdown chunks (e.g. the per-model
+                # title / chain / non-standard-residue sections that follow
+                # an `open`), and a literal '; ' between them produced stray
+                # leading-semicolon lines in the rendered output. Trailing
+                # newlines inside individual messages plus this separator
+                # collapse to a single blank line via _BLANK_LINE_RUN_RE.
+                output.append(f"{level.upper()}:\n" + "\n\n".join(filtered_messages))
                 has_log_content = True
     
     # Priority 2: If no log content, try json values

--- a/src/bundles/mcp_server/src/cmd.py
+++ b/src/bundles/mcp_server/src/cmd.py
@@ -7,7 +7,10 @@ from chimerax.core.errors import UserError
 #   label:           human-readable name used in messages
 #   config_dirs:     per-platform directory that contains the config file;
 #                    the directory must exist (= the host is installed/has
-#                    been launched at least once) before we will write to it
+#                    been launched at least once) before we will write to it.
+#                    On Windows, values that start with "~" are expanded
+#                    against %USERPROFILE% (via os.path.expanduser); other
+#                    values are joined with %APPDATA%.
 #   filename:        name of the config file in that directory
 #   schema:          top-level JSON key under which MCP server entries live
 #                    ("mcpServers" for Claude Desktop / Cursor, "servers"
@@ -28,9 +31,12 @@ _HOSTS = {
     "cursor": {
         "label": "Cursor",
         "config_dirs": {
+            # Cursor's docs state that ~/.cursor/mcp.json is the global
+            # config location on all platforms, including Windows
+            # (https://cursor.com/docs/mcp).
             "darwin": "~/.cursor",
             "linux":  "~/.cursor",
-            "win32":  "Cursor",  # joined with %APPDATA%
+            "win32":  "~/.cursor",  # expanded against %USERPROFILE%
         },
         "filename": "mcp.json",
         "schema":   "mcpServers",
@@ -199,6 +205,15 @@ def _resolve_config_dir(host):
         if 'win32' not in config_dirs:
             raise UserError(
                 f'{host["label"]} is not supported on Windows by mcp setup.')
+        win_dir = config_dirs['win32']
+        # Some hosts (e.g. Cursor) put their global config under the user
+        # profile (~/.cursor/mcp.json on all platforms), not under %APPDATA%.
+        # Treat values starting with "~" as home-relative and let
+        # os.path.expanduser pick up %USERPROFILE%; everything else is a
+        # subdirectory under %APPDATA%.
+        if win_dir.startswith('~'):
+            from os.path import expanduser, normpath
+            return normpath(expanduser(win_dir))
         from os import environ
         appdata_dir = environ.get('APPDATA')
         if not appdata_dir:
@@ -206,7 +221,7 @@ def _resolve_config_dir(host):
                 f'Could not determine {host["label"]} configuration directory '
                 f'because APPDATA environment variable not set')
         from os.path import join, normpath
-        return normpath(join(appdata_dir, config_dirs['win32']))
+        return normpath(join(appdata_dir, win_dir))
     else:
         # Linux / other
         linux_dir = config_dirs.get('linux')

--- a/src/bundles/mcp_server/src/cmd.py
+++ b/src/bundles/mcp_server/src/cmd.py
@@ -1,5 +1,55 @@
-from chimerax.core.commands import CmdDesc, register, IntArg, BoolArg
+from chimerax.core.commands import CmdDesc, register, IntArg, BoolArg, EnumOf
 from chimerax.core.errors import UserError
+
+
+# Table of MCP-capable AI assistants ("hosts") this bundle knows how to
+# configure. Each entry describes:
+#   label:           human-readable name used in messages
+#   config_dirs:     per-platform directory that contains the config file;
+#                    the directory must exist (= the host is installed/has
+#                    been launched at least once) before we will write to it
+#   filename:        name of the config file in that directory
+#   schema:          top-level JSON key under which MCP server entries live
+#                    ("mcpServers" for Claude Desktop / Cursor, "servers"
+#                    for VS Code Copilot)
+#   needs_type_stdio: whether each server entry must include "type": "stdio"
+#                    (true for VS Code Copilot's mcp.json schema)
+_HOSTS = {
+    "claude": {
+        "label": "Claude Desktop",
+        "config_dirs": {
+            "darwin": "~/Library/Application Support/Claude",
+            "win32":  "Claude",  # joined with %APPDATA%
+        },
+        "filename": "claude_desktop_config.json",
+        "schema":   "mcpServers",
+        "needs_type_stdio": False,
+    },
+    "cursor": {
+        "label": "Cursor",
+        "config_dirs": {
+            "darwin": "~/.cursor",
+            "linux":  "~/.cursor",
+            "win32":  "Cursor",  # joined with %APPDATA%
+        },
+        "filename": "mcp.json",
+        "schema":   "mcpServers",
+        "needs_type_stdio": False,
+    },
+    "vscode": {
+        "label": "VS Code Copilot",
+        "config_dirs": {
+            "darwin": "~/Library/Application Support/Code/User",
+            "linux":  "~/.config/Code/User",
+            "win32":  "Code/User",  # joined with %APPDATA%
+        },
+        "filename": "mcp.json",
+        "schema":   "servers",
+        "needs_type_stdio": True,
+    },
+}
+
+_HOST_CHOICES = list(_HOSTS.keys()) + ["all"]
 
 
 def mcp_start(session, port=8080):
@@ -93,10 +143,13 @@ def mcp_stop(session):
 
 
 def mcp_info(session):
-    """Show MCP server status and configuration"""
+    """Show MCP server status and AI-assistant host configuration"""
 
-    # Check Claude Desktop configuration file
-    config_status = _check_claude_configuration(session)
+    # Per-host configuration status
+    host_lines = []
+    for host_id in _HOSTS:
+        host_lines.append(_check_host_configuration(host_id))
+    config_status = "<br>".join(host_lines)
 
     # Check REST server status and configuration
     rest_server = _get_rest_server()
@@ -107,7 +160,7 @@ def mcp_info(session):
 
         rest_status = f"REST server is running on port {port}<br>"
         if not (json_enabled and log_enabled):
-            rest_status += "<br>&nbsp;&nbsp;💡 Run 'mcp start' to enable JSON and logging required MCP"
+            rest_status += "<br>&nbsp;&nbsp;💡 Run 'mcp start' to enable JSON and logging required by MCP"
     else:
         rest_status = f"REST server is not running, start it with ChimeraX command 'mcp start'"
 
@@ -116,78 +169,226 @@ def mcp_info(session):
 
     return status_info
 
-def _check_claude_configuration(session):
+
+def _check_host_configuration(host_id):
+    """Return a single-line status string for the given AI-assistant host."""
+    host = _HOSTS[host_id]
+    label = host["label"]
     try:
-        msg = mcp_setup(session, check_only = True)
+        msg = _setup_host(None, host_id, check_only=True)
+        return f"{label}: {msg}"
     except UserError as e:
-        msg = str(e)
-    return msg
+        return f"{label}: {str(e)}"
 
-def mcp_setup(session, config_file_name = 'claude_desktop_config.json', check_only = False):
-    "Write Claude Desktop configuration file to allow it to control ChimeraX using MCP."
 
+def _resolve_config_dir(host):
+    """Resolve the platform-specific config directory for a host descriptor.
+
+    Returns the absolute path, or raises UserError if this platform is not
+    supported for that host.
+    """
     from sys import platform
+    config_dirs = host["config_dirs"]
     if platform == 'darwin':
+        if 'darwin' not in config_dirs:
+            raise UserError(
+                f'{host["label"]} is not supported on macOS by mcp setup.')
         from os.path import expanduser
-        config_dir = expanduser('~/Library/Application Support/Claude')
+        return expanduser(config_dirs['darwin'])
     elif platform == 'win32':
+        if 'win32' not in config_dirs:
+            raise UserError(
+                f'{host["label"]} is not supported on Windows by mcp setup.')
         from os import environ
         appdata_dir = environ.get('APPDATA')
         if not appdata_dir:
-            from chimerax.core.errors import UserError
-            raise UserError('Could not determine Claude Desktop configuration directory because APPDATA environment variable not set')
-        from os.path import join
-        config_dir = join(appdata_dir, 'Claude')
+            raise UserError(
+                f'Could not determine {host["label"]} configuration directory '
+                f'because APPDATA environment variable not set')
+        from os.path import join, normpath
+        return normpath(join(appdata_dir, config_dirs['win32']))
     else:
-        from chimerax.core.errors import UserError
-        raise UserError(f'Location of Claude Desktop configuration directory on "{platform}" is unknown')
+        # Linux / other
+        linux_dir = config_dirs.get('linux')
+        if linux_dir is None:
+            raise UserError(
+                f'Location of {host["label"]} configuration directory on '
+                f'"{platform}" is unknown')
+        from os.path import expanduser
+        return expanduser(linux_dir)
 
-    from os.path import isdir
+
+def mcp_setup(session, host="claude", check_only=False):
+    """Write a configuration file for an MCP-capable AI assistant so it can
+    control ChimeraX using MCP.
+
+    host: one of 'claude' (Claude Desktop, default), 'cursor', 'vscode'
+          (VS Code Copilot), or 'all' to configure every host whose
+          configuration directory is present on this machine.
+    """
+    if host == "all":
+        results = []
+        for host_id in _HOSTS:
+            try:
+                msg = _setup_host(session, host_id, check_only=check_only)
+                if msg is not None:
+                    results.append(f"{_HOSTS[host_id]['label']}: {msg}")
+            except UserError as e:
+                results.append(f"{_HOSTS[host_id]['label']}: {e}")
+        if check_only:
+            return "\n".join(results)
+        for r in results:
+            session.logger.info(r)
+        return
+
+    if host not in _HOSTS:
+        raise UserError(
+            f'Unknown host "{host}". Choose one of: '
+            f'{", ".join(sorted(_HOSTS.keys()))}, all')
+
+    return _setup_host(session, host, check_only=check_only)
+
+
+def _load_host_config(path):
+    """Read a host's MCP config file, tolerating empty files and JSONC.
+
+    Cursor and VS Code both accept JSONC (// line comments, /* */ block
+    comments, and trailing commas) for their mcp.json. ChimeraX does not
+    bundle a JSONC parser, so we strip those constructs ourselves before
+    a second parse attempt.
+
+    Returns (config_data, had_jsonc).
+    Raises ValueError with a friendly message if the file cannot be parsed
+    even after JSONC cleanup.
+    """
+    import json
+    import re
+    with open(path, 'r') as f:
+        text = f.read()
+    if not text.strip():
+        return {}, False
+    try:
+        return json.loads(text), False
+    except json.JSONDecodeError:
+        # Block comments first (so a // inside /* ... */ doesn't confuse us).
+        cleaned = re.sub(r"/\*.*?\*/", "", text, flags=re.S)
+        # Line comments. The (^|[^:]) guard avoids stripping `://` inside
+        # URLs (e.g. Cursor entries with "url": "http://...").
+        cleaned = re.sub(r"(^|[^:])//[^\n]*", r"\1", cleaned)
+        # Trailing commas before } or ].
+        cleaned = re.sub(r",(\s*[}\]])", r"\1", cleaned)
+        try:
+            return json.loads(cleaned), True
+        except json.JSONDecodeError as e:
+            raise ValueError(
+                f'Could not parse "{path}" as JSON or JSONC: {e}')
+
+
+def _setup_host(session, host_id, check_only=False):
+    """Write (or check) the configuration file for one host.
+
+    When check_only is True, returns a status string and never modifies any
+    files (session may be None in this mode).
+    """
+    host = _HOSTS[host_id]
+    config_dir = _resolve_config_dir(host)
+
+    from os.path import isdir, isfile, join
     if not isdir(config_dir):
-        from chimerax.core.errors import UserError
-        raise UserError(f'The Claude Desktop configuration directory "{config_dir}" does not exist.  You need to install Claude Desktop on your computer and run it before configuring it for use with ChimeraX.')
+        raise UserError(
+            f'The {host["label"]} configuration directory "{config_dir}" '
+            f'does not exist. You need to install {host["label"]} on your '
+            f'computer and run it once before configuring it for use with '
+            f'ChimeraX.')
 
-    from os.path import join, isfile
-    config_path = join(config_dir, config_file_name)
-    if isfile(config_path):
-        with open(config_path, 'r') as f:
-            import json
-            config_data = json.load(f)
-        mcp_config = config_data.get('mcpServers')
-        if mcp_config:
-            if 'chimerax' in mcp_config:
-                command_path = mcp_config['chimerax']['command']
+    config_path = join(config_dir, host["filename"])
+    schema_key = host["schema"]
+
+    had_jsonc = False
+    config_existed = isfile(config_path)
+    if config_existed:
+        try:
+            config_data, had_jsonc = _load_host_config(config_path)
+        except ValueError as e:
+            if check_only:
+                return f'existing config file could not be parsed: {e}'
+            raise UserError(
+                f'{host["label"]} configuration file "{config_path}" could '
+                f'not be parsed: {e}. Fix or remove it before running '
+                f'"mcp setup".')
+        if not config_data:
+            config_data = {schema_key: {}}
+        servers = config_data.get(schema_key)
+        if servers:
+            if 'chimerax' in servers:
+                command_path = servers['chimerax'].get('command', '')
                 config_chimerax_path = _chimerax_directory_from_executable(command_path)
                 import sys
                 current_chimerax_path = _chimerax_directory_from_executable(sys.executable)
                 if config_chimerax_path == current_chimerax_path:
-                    msg = f'The Claude Desktop configuration file "{config_path}" is already set up to use ChimeraX.'
+                    msg = f'configured to use this ChimeraX (file "{config_path}")'
                     if check_only:
                         return msg
-                    from chimerax.core.errors import UserError
-                    raise UserError(msg)
-                msg = f'Claude is configured to use a different ChimeraX version {config_chimerax_path}.'
+                    raise UserError(
+                        f'The {host["label"]} configuration file '
+                        f'"{config_path}" is already set up to use ChimeraX.')
+                msg = (f'configured to use a different ChimeraX version '
+                       f'{config_chimerax_path}')
                 if check_only:
                     return msg
-                msg += f' The configuration will be updated to use the ChimeraX you are now running {current_chimerax_path}'
-                session.logger.info(msg)
+                session.logger.info(
+                    f'{host["label"]} {msg}. The configuration will be '
+                    f'updated to use the ChimeraX you are now running '
+                    f'{current_chimerax_path}')
         else:
-            config_data['mcpServers'] = {}
+            config_data[schema_key] = {}
     else:
-        config_data = {'mcpServers': {}}
+        config_data = {schema_key: {}}
 
     if check_only:
-        return 'Claude Desktop is not configured to use ChimeraX.  Run the ChimeraX command "mcp setup" to write the Claude Desktop configuration file.'
+        return (f'not configured to use ChimeraX. Run the ChimeraX command '
+                f'"mcp setup host {host_id}" to write the {host["label"]} '
+                f'configuration file.')
 
-    config_data['mcpServers']['chimerax'] = _mcp_configuration_data()
+    config_data[schema_key]['chimerax'] = _mcp_configuration_data(host)
+
+    # Snapshot the previous file before we overwrite it, so the user can
+    # restore comments / original formatting if anything looks off.
+    backup_path = None
+    if config_existed:
+        import shutil
+        backup_path = config_path + '.bak'
+        try:
+            shutil.copyfile(config_path, backup_path)
+        except OSError as e:
+            session.logger.warning(
+                f'Could not create backup "{backup_path}" before rewriting '
+                f'{host["label"]} config: {e}')
+            backup_path = None
 
     with open(config_path, 'w') as f:
         import json
         json.dump(config_data, f, indent=4)
 
-    session.logger.info(f'Updated Claude Desktop configuration file {config_path} to use ChimeraX')
+    session.logger.info(
+        f'Updated {host["label"]} configuration file {config_path} to use '
+        f'ChimeraX')
 
-def _mcp_configuration_data():
+    if had_jsonc:
+        bak_msg = (f' The previous contents are saved at "{backup_path}".'
+                   if backup_path else '')
+        session.logger.warning(
+            f'{host["label"]} configuration file "{config_path}" contained '
+            f'comments or trailing commas; ChimeraX has rewritten it as '
+            f'strict JSON and comments are no longer preserved.{bak_msg}')
+
+
+def _mcp_configuration_data(host):
+    """Build the per-host MCP server entry for ChimeraX.
+
+    Adds "type": "stdio" for hosts (e.g. VS Code Copilot) whose schema
+    requires it.
+    """
     # Get the bridge script path
     from os.path import dirname, join, realpath
     bundle_dir = dirname(__file__)
@@ -201,12 +402,16 @@ def _mcp_configuration_data():
         python_executable_dir = join(dirname(python_executable_dir), 'bin')
     python_executable_name = 'python.exe' if platform == 'win32' else f'python{version_info.major}.{version_info.minor}'
     python_path = join(python_executable_dir, python_executable_name)
-    
+
     mcp_config = {
         'command': python_path,
         'args': [bridge_path]
     }
+    if host.get("needs_type_stdio"):
+        # Insert "type" first for nicer JSON ordering
+        mcp_config = {'type': 'stdio', **mcp_config}
     return mcp_config
+
 
 def _chimerax_directory_from_executable(exec_path):
     from sys import platform
@@ -216,7 +421,8 @@ def _chimerax_directory_from_executable(exec_path):
     for count in range(num_levels):
         path = dirname(path)
     return path
-        
+
+
 mcp_start_desc = CmdDesc(
     optional=[("port", IntArg)],
     synopsis="Start REST server for MCP bridge connections (default port: 8080)",
@@ -224,9 +430,14 @@ mcp_start_desc = CmdDesc(
 
 mcp_stop_desc = CmdDesc(synopsis="Stop the REST server")
 
-mcp_info_desc = CmdDesc(synopsis="Show MCP bridge status and configuration")
+mcp_info_desc = CmdDesc(synopsis="Show MCP bridge status and AI-assistant host configuration")
 
-mcp_setup_desc = CmdDesc(synopsis="Write Claude Desktop configuration file to allow it to control ChimeraX using MCP.")
+mcp_setup_desc = CmdDesc(
+    keyword=[("host", EnumOf(_HOST_CHOICES))],
+    synopsis="Write a configuration file for an MCP-capable AI assistant "
+             "(Claude Desktop, Cursor, VS Code Copilot) so it can control "
+             "ChimeraX using MCP.",
+)
 
 
 def register_commands(logger):


### PR DESCRIPTION
## Summary

Fixes a number of rough edges in the ChimeraX MCP bridge that surfaced when
exercising it from clients other than Claude Desktop (Cursor, VS Code Copilot).
The visible effects are: tool results no longer appear two or three times in
the chat (this saves tokens), `get_command_documentation` actually returns something for bundle
and hierarchical commands, and the setup docs call out non-Claude clients.


## Commits

- **`92de7af9` mcp_server: replace stderr prints with logger** — Diagnostic
  output in the bridge was using `print(..., file=sys.stderr)`. Cursor's MCP
  client tagged every line as `[error]`, and FastMCP additionally re-emitted
  stderr as MCP notifications, so each message appeared twice. Switched to
  `logging`, replaced the ad-hoc `DEBUG` `/tmp/` dump with `logger.debug()`.

- **`24eec03c` mcp_server: add error hint for hierarchical "Incomplete
  command"** — When the agent runs a category prefix like `isolde`,
  `clipper`, or `volume` without a sub-action, ChimeraX raises
  `UserError: Incomplete command`. Added a branch in `add_error_hints()` that
  tells the agent to consult `help <prefix>` and re-issue with a full
  sub-action, instead of retrying the same prefix or guessing.

- **`966fe00f` mcp_server: `get_command_documentation` falls back to live
  `usage`** — Previously only the local HTML reference was consulted, which
  doesn't cover bundle commands (`isolde`, …) or hierarchical sub-paths
  (`isolde validate`). Now single-word inputs still hit the local HTML, but
  multi-word inputs (and any miss) fall back to running `usage <stripped>`
  in the live session and formatting the result. Renamed the argument from
  `command_name` to `command` to match the new multi-word semantics; updated
  sibling docstrings in `run_command` and `list_chimerax_commands`.

- **`7a382050` mcp_server: disable FastMCP structured-output wrapping for all
  tools** — FastMCP's default for `str`-returning tools is to also emit a
  `structuredContent: {"result": "..."}` block alongside the plain text.
  Clients that surface both (e.g. VS Code Copilot) showed every tool result
  twice. Pass `structured_output=False` to every `@mcp.tool()` decorator so
  the server emits unstructured text content only.

- **`6f1ee879` mcp_server: tighten command-echo filter in
  `format_chimerax_response`** — ChimeraX's REST log echoes each executed
  command in multiple forms (plain text and `[cmd](cxcmd:cmd)` markdown
  link), and occasionally prefixes continuations with `; `. The previous
  filter only dropped messages with ≥2 markdown links, so the single-link
  cxcmd echo and the plain-text echo both leaked through. Extracted a
  `_clean_log_message` helper that drops the single-link cxcmd form, drops
  the plain-text echo when it equals the executed command (new optional
  `command` argument), strips the leading `; `, and discards messages that
  become empty. Also collapses runs of ≥3 consecutive newlines down to one
  blank line.

- **`439cd8a4` mcp_server: shorten tool context lines and thread command into
  formatter** — Tool wrappers were prepending verbose lines like
  `Command executed on session 8080: <cmd>`, duplicating info the agent
  already has from the tool args. Combined with the command echoes in the
  log, the same command often appeared three times in one tool result.
  Replaced those with a compact `[session N]` annotation (empty for the
  default session) in `run_command`, `open_structure`, `list_models`,
  `color_models`, `save_image`, and `get_command_documentation`, and
  pass the executed command into `format_chimerax_response` so the matching
  echo is filtered. Tools with genuinely informative context (model / chain
  info, `Successfully superposed residue`) keep their existing strings.

- **`8e3d648d` mcp_server: update log-message formatting in
  `format_chimerax_response`** — Changed the separator for filtered log
  messages from `'; '` to `'\n\n'`, so multi-line markdown chunks render
  cleanly and trailing newlines inside individual messages collapse to a
  single blank line instead of leaking stray leading-semicolon lines.

- **`bacb5cf7` mcp setup now also supports Cursor and VS Code** — Docs-only.
  Updated the setup documentation to cover Cursor and VS Code in addition to
  Claude Desktop, and reworded sections to distinguish Claude-specific
  features from general MCP-client features. Claude remains the default;
  fully backward compatible.

## Tests

I have tested all but one of these commits pretty extensively from Cursor and VSCode Copilot over a period of several days. 
The exception is the last commit (`bacb5cf7`), which tweaks the `mcp setup` command - I only tested this against my Cursor configuration and on MacOS. I don't have any way to test on other operating systems.
