### PR TITLE
Fix ArrayJSONEncoder failing to serialize numpy scalars

### DIFF
--- a/src/bundles/core/src/commands/run.py
+++ b/src/bundles/core/src/commands/run.py
@@ -81,6 +81,12 @@ class ArrayJSONEncoder(json.JSONEncoder):
         # Does this look like an array?
         if hasattr(val, "__len__") and hasattr(val, "shape"):
             return [self._translate(v) for v in val]
+        import numpy
+        # A bare numpy scalar (e.g. the numpy.int64 from arr.sum()) has 'shape'
+        # but not '__len__', so it skips the array branch above; coerce it to a
+        # native Python type rather than failing to encode.
+        if isinstance(val, numpy.generic):
+            return self._translate(val)
         if self._user_default is None:
             raise TypeError("Can't JSON-encode '%s'" % repr(val))
         return self._user_default(val)
@@ -89,6 +95,8 @@ class ArrayJSONEncoder(json.JSONEncoder):
         if hasattr(val, "__len__"):
             return [self._translate(v) for v in val]
         import numpy
+        if isinstance(val, numpy.bool_):
+            return bool(val)
         if isinstance(val, numpy.number):
             if isinstance(val, numpy.integer):
                 return int(val)

--- a/src/bundles/core/tests/test_array_json_encoder.py
+++ b/src/bundles/core/tests/test_array_json_encoder.py
@@ -1,0 +1,54 @@
+import json
+
+import pytest
+
+
+def test_encode_numpy_int_scalar():
+    # Regression for sbagent#40: arr.sum() yields a numpy.int64 scalar, which
+    # has 'shape' but no '__len__'. Previously this raised
+    # "TypeError: Can't JSON-encode '1'".
+    import numpy
+    from chimerax.core.commands.run import ArrayJSONEncoder
+
+    val = numpy.array([True]).sum()  # numpy.int64(1)
+    assert json.loads(ArrayJSONEncoder().encode({"n": val})) == {"n": 1}
+
+
+def test_encode_numpy_float_scalar():
+    # Regression for sbagent#33: numpy.float32 from an info attribute path.
+    import numpy
+    from chimerax.core.commands.run import ArrayJSONEncoder
+
+    val = numpy.float32(0.24107859)
+    decoded = json.loads(ArrayJSONEncoder().encode({"x": val}))["x"]
+    assert isinstance(decoded, float)
+    assert decoded == pytest.approx(float(val))
+
+
+def test_encode_numpy_bool_scalar():
+    import numpy
+    from chimerax.core.commands.run import ArrayJSONEncoder
+
+    assert json.loads(ArrayJSONEncoder().encode({"b": numpy.bool_(True)})) == {"b": True}
+
+
+def test_encode_nested_numpy_arrays():
+    # The existing array path must keep working (no regression).
+    import numpy
+    from chimerax.core.commands.run import ArrayJSONEncoder
+
+    payload = {"a": numpy.array([1, 2, 3]), "b": [numpy.array([4.0, 5.0])]}
+    assert json.loads(ArrayJSONEncoder().encode(payload)) == {
+        "a": [1, 2, 3],
+        "b": [[4.0, 5.0]],
+    }
+
+
+def test_unencodable_object_still_raises():
+    from chimerax.core.commands.run import ArrayJSONEncoder
+
+    class Opaque:
+        pass
+
+    with pytest.raises(TypeError):
+        ArrayJSONEncoder().encode({"o": Opaque()})


### PR DESCRIPTION
## Fix ArrayJSONEncoder failing to serialize numpy scalars

### Problem

`ArrayJSONEncoder` (the JSON encoder used by the command system's `return_json` path) crashes when asked to serialize a bare numpy scalar, raising `TypeError: Can't JSON-encode '<value>'`.

This surfaced through the ChimeraX MCP bridge's `list_models` tool, which runs the bare `info` command in JSON mode. In a **GUI session with an active selection**, `list_info`'s `model_info()` sets `info_dict['num selected instances'] = m.selected_positions.sum()` — a `numpy.int64` scalar — and the encoder crashes with `Can't JSON-encode '1'`. The same class of bug was previously seen with a `numpy.float32` value via `info atoms ... attribute mapvalue`.

It only reproduces in a GUI session with a selection: in `--nogui`, `selected_positions` is `None`, so `info` returns Python `0` and never trips the encoder — which is why headless tests missed it.

### Root cause

`ArrayJSONEncoder` already has a `_translate` helper that correctly coerces numpy types to native Python. But its `default` hook, `_encode_array`, only routed values through `_translate` when they had **both** `__len__` and `shape`:

```python
if hasattr(val, "__len__") and hasattr(val, "shape"):
    return [self._translate(v) for v in val]
...
raise TypeError("Can't JSON-encode '%s'" % repr(val))
```

A bare numpy scalar (e.g. the `numpy.int64` from `arr.sum()`) has `shape` but **not** `__len__`, so it skipped `_translate` and hit the `raise`.

### Fix

At the encoder — the highest-leverage layer, fixing the whole class at once:

- `_encode_array` now routes bare numpy scalars (`isinstance(val, numpy.generic)`) through `_translate` before raising.
- `_translate` now also handles `numpy.bool_` (which is **not** a `numpy.number` subclass and would otherwise be returned unchanged and loop back into the `default` hook).

This covers `numpy.int64`, `numpy.float32`, and `numpy.bool_` in one place. The existing array path and user-supplied `default` behavior are unchanged.

### Testing

- New `src/bundles/core/tests/test_array_json_encoder.py`: the `numpy.int64` repro (`np.array([True]).sum()` → `1`), the `numpy.float32` repro, a `numpy.bool_` case, a nested-array no-regression case, and a check that a truly un-encodable object still raises `TypeError`. All 5 pass.
- Rebuilt and reinstalled the `core` bundle and verified the encoder against the rebuilt code.
- End-to-end: confirmed via the MCP bridge in a GUI session with an open structure + map and an active selection — `list_models` now returns a normal model listing instead of `TypeError: Can't JSON-encode '1'`.

### Files

- `src/bundles/core/src/commands/run.py` — encoder fix
- `src/bundles/core/tests/test_array_json_encoder.py` — regression test
