### PR TITLE
Feature/fasthydromap command

### DIFF
--- a/src/bundles/Makefile
+++ b/src/bundles/Makefile
@@ -28,7 +28,7 @@ REST_SUBDIRS = add_charge addh alignment_algs alignment_headers \
 	  color_globe color_key connect_structure core_formats \
 	  coulombic crosslinks crystal crystal_contacts data_formats \
 	  dicom dist_monitor dock_prep dssp \
-	  emdb_sff esmfold file_history function_key \
+	  emdb_sff esmfold fasthydromap file_history function_key \
 	  geometry gltf graphics \
 	  hbonds help_viewer hkcage ihm image_formats imod \
 	  interfaces items_inspection io label iupac \

--- a/src/bundles/fasthydromap/CHANGELOG.md
+++ b/src/bundles/fasthydromap/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+## 0.1.1
+
+- Exclude nucleic acids, waters, ions, and ligands from the temporary
+  FastHydroMap prediction input without deleting them from the open ChimeraX
+  model.
+- Report how many non-protein residues were omitted.
+- Warn during prediction when DNA, RNA, waters, ions, or ligands are ignored,
+  and when histidine tautomer/protonation states cannot be represented.
+- Add a ChimeraX tutorial explaining why Fdewet is context-aware, what the
+  PC1-PC3 sign conventions represent, and how to control the maps.
+- Show clickable quick-start and help commands when the managed installation
+  finishes.
+
+## 0.1.0
+
+- Initial ChimeraX Toolshed release.
+- Predict and color Fdewet, PC1, PC2, and PC3 residue maps.
+- Install FastHydroMap and PyTorch in an isolated, bundle-managed environment.

--- a/src/bundles/fasthydromap/LICENSE
+++ b/src/bundles/fasthydromap/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Samuel Lobo
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/bundles/fasthydromap/Makefile
+++ b/src/bundles/fasthydromap/Makefile
@@ -1,0 +1,1 @@
+include ../Makefile.bundle

--- a/src/bundles/fasthydromap/README.md
+++ b/src/bundles/fasthydromap/README.md
@@ -1,7 +1,17 @@
 # FastHydroMap for ChimeraX
 
+![FastHydroMap overview](https://raw.githubusercontent.com/samlobe/FastHydroMap/main/images/FastHydroMap_image.png)
+
 This ChimeraX bundle predicts per-residue FastHydroMap Fdewet and water-structure
 PC maps and colors the corresponding atoms, cartoons, and molecular surfaces.
+Non-protein components such as nucleic acids, waters, ions, and ligands remain in
+the ChimeraX scene but are excluded from prediction.
+
+Install the bundle from ChimeraX's **Tools > More Tools...** page or run:
+
+```text
+toolshed install FastHydroMap
+```
 
 The first use requires a one-time installation of FastHydroMap and PyTorch into
 an isolated environment managed by the bundle:
@@ -23,5 +33,10 @@ fasthydromap #1 quantity pc1 target cs
 ```
 
 See `help fasthydromap` inside ChimeraX for all options and installation notes.
+For a complete walkthrough, including why Fdewet is context-aware and how to
+interpret the PC1-PC3 sign conventions, see the
+[FastHydroMap ChimeraX tutorial](https://github.com/samlobe/FastHydroMap/blob/main/docs/ChimeraX_tutorial.md).
 
 FastHydroMap is developed at <https://github.com/samlobe/FastHydroMap>.
+The method is described in Lobo, Najafi, Shea, and Shell,
+[*Context-Aware Hydrophobicity Modeling: HydroMap and FastHydroMap*](https://doi.org/10.64898/2026.06.07.730647).

--- a/src/bundles/fasthydromap/README.md
+++ b/src/bundles/fasthydromap/README.md
@@ -1,0 +1,27 @@
+# FastHydroMap for ChimeraX
+
+This ChimeraX bundle predicts per-residue FastHydroMap Fdewet and water-structure
+PC maps and colors the corresponding atoms, cartoons, and molecular surfaces.
+
+The first use requires a one-time installation of FastHydroMap and PyTorch into
+an isolated environment managed by the bundle:
+
+```text
+fasthydromap install
+```
+
+Open a protein structure and run:
+
+```text
+fasthydromap #1
+```
+
+The `quantity` option accepts `fdewet`, `pc1`, `pc2`, or `pc3`. For example:
+
+```text
+fasthydromap #1 quantity pc1 target cs
+```
+
+See `help fasthydromap` inside ChimeraX for all options and installation notes.
+
+FastHydroMap is developed at <https://github.com/samlobe/FastHydroMap>.

--- a/src/bundles/fasthydromap/pyproject.toml
+++ b/src/bundles/fasthydromap/pyproject.toml
@@ -22,9 +22,10 @@ text = """Predict per-residue FastHydroMap Fdewet and water-structure PC maps fr
 
 [project.urls]
 Home = "https://github.com/samlobe/FastHydroMap"
-Documentation = "https://github.com/samlobe/FastHydroMap#readme"
+Documentation = "https://github.com/samlobe/FastHydroMap/blob/main/docs/ChimeraX_tutorial.md"
 Source = "https://github.com/samlobe/ChimeraX/tree/feature/fasthydromap-command/src/bundles/fasthydromap"
 Issues = "https://github.com/samlobe/FastHydroMap/issues"
+Publication = "https://doi.org/10.64898/2026.06.07.730647"
 
 [tool.setuptools.dynamic]
 version = { attr = "src.__version__" }

--- a/src/bundles/fasthydromap/pyproject.toml
+++ b/src/bundles/fasthydromap/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "chimerax.bundle_builder.cx_pep517"
 [project]
 name = "ChimeraX-FastHydroMap"
 license = "MIT"
-authors = [{ name = "Samuel Lobo" }]
+authors = [{ name = "Samuel Lobo", email = "samuels.lobo@gmail.com" }]
 description = "Run FastHydroMap from ChimeraX and color structures by predicted Fdewet or PC maps"
 dependencies = [
   "ChimeraX-Core ~=1.0",
@@ -18,10 +18,13 @@ dynamic = ["classifiers", "requires-python", "version"]
 
 [project.readme]
 content-type = "text"
-text = """Install FastHydroMap from PyPI into a managed ChimeraX environment and color atomic structures by predicted Fdewet or PC maps."""
+text = """Predict per-residue FastHydroMap Fdewet and water-structure PC maps from inside ChimeraX. The bundle manages an isolated FastHydroMap installation, assigns predictions as residue attributes, and colors atoms, cartoons, and molecular surfaces."""
 
 [project.urls]
-Home = "https://www.rbvi.ucsf.edu/chimerax/"
+Home = "https://github.com/samlobe/FastHydroMap"
+Documentation = "https://github.com/samlobe/FastHydroMap#readme"
+Source = "https://github.com/samlobe/ChimeraX/tree/feature/fasthydromap-command/src/bundles/fasthydromap"
+Issues = "https://github.com/samlobe/FastHydroMap/issues"
 
 [tool.setuptools.dynamic]
 version = { attr = "src.__version__" }
@@ -30,7 +33,13 @@ version = { attr = "src.__version__" }
 min-session-version = 1
 max-session-version = 1
 categories = ["Structure Analysis"]
-classifiers = ["Development Status :: 2 - Pre-Alpha"]
+classifiers = [
+  "Development Status :: 3 - Alpha",
+  "License :: OSI Approved :: MIT License",
+]
+
+[tool.chimerax.package-data]
+"src/docs/user/commands" = ["*.html"]
 
 [tool.chimerax.command.fasthydromap]
 category = "Structure Analysis"

--- a/src/bundles/fasthydromap/pyproject.toml
+++ b/src/bundles/fasthydromap/pyproject.toml
@@ -1,0 +1,41 @@
+[build-system]
+requires = ["setuptools", "ChimeraX-BundleBuilder"]
+build-backend = "chimerax.bundle_builder.cx_pep517"
+
+[project]
+name = "ChimeraX-FastHydroMap"
+license = "MIT"
+authors = [{ name = "Samuel Lobo" }]
+description = "Run FastHydroMap from ChimeraX and color structures by predicted Fdewet"
+dependencies = [
+  "ChimeraX-Core ~=1.0",
+  "ChimeraX-Atomic >=1.66",
+  "ChimeraX-PDB >=2.0",
+  "ChimeraX-Surface >=1.0",
+]
+
+dynamic = ["classifiers", "requires-python", "version"]
+
+[project.readme]
+content-type = "text"
+text = """Install FastHydroMap from PyPI into a managed ChimeraX environment and color atomic structures by predicted Fdewet."""
+
+[project.urls]
+Home = "https://www.rbvi.ucsf.edu/chimerax/"
+
+[tool.setuptools.dynamic]
+version = { attr = "src.__version__" }
+
+[tool.chimerax]
+min-session-version = 1
+max-session-version = 1
+categories = ["Structure Analysis"]
+classifiers = ["Development Status :: 2 - Pre-Alpha"]
+
+[tool.chimerax.command.fasthydromap]
+category = "Structure Analysis"
+description = "Predict per-residue Fdewet with FastHydroMap"
+
+[tool.chimerax.command."fasthydromap install"]
+category = "Structure Analysis"
+description = "Install FastHydroMap from PyPI in a managed ChimeraX environment"

--- a/src/bundles/fasthydromap/pyproject.toml
+++ b/src/bundles/fasthydromap/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "chimerax.bundle_builder.cx_pep517"
 name = "ChimeraX-FastHydroMap"
 license = "MIT"
 authors = [{ name = "Samuel Lobo" }]
-description = "Run FastHydroMap from ChimeraX and color structures by predicted Fdewet"
+description = "Run FastHydroMap from ChimeraX and color structures by predicted Fdewet or PC maps"
 dependencies = [
   "ChimeraX-Core ~=1.0",
   "ChimeraX-Atomic >=1.66",
@@ -18,7 +18,7 @@ dynamic = ["classifiers", "requires-python", "version"]
 
 [project.readme]
 content-type = "text"
-text = """Install FastHydroMap from PyPI into a managed ChimeraX environment and color atomic structures by predicted Fdewet."""
+text = """Install FastHydroMap from PyPI into a managed ChimeraX environment and color atomic structures by predicted Fdewet or PC maps."""
 
 [project.urls]
 Home = "https://www.rbvi.ucsf.edu/chimerax/"
@@ -34,7 +34,7 @@ classifiers = ["Development Status :: 2 - Pre-Alpha"]
 
 [tool.chimerax.command.fasthydromap]
 category = "Structure Analysis"
-description = "Predict per-residue Fdewet with FastHydroMap"
+description = "Predict per-residue Fdewet or PC maps with FastHydroMap"
 
 [tool.chimerax.command."fasthydromap install"]
 category = "Structure Analysis"

--- a/src/bundles/fasthydromap/pyproject.toml
+++ b/src/bundles/fasthydromap/pyproject.toml
@@ -35,7 +35,6 @@ max-session-version = 1
 categories = ["Structure Analysis"]
 classifiers = [
   "Development Status :: 3 - Alpha",
-  "License :: OSI Approved :: MIT License",
 ]
 
 [tool.chimerax.package-data]

--- a/src/bundles/fasthydromap/pyproject.toml
+++ b/src/bundles/fasthydromap/pyproject.toml
@@ -8,7 +8,7 @@ license = "MIT"
 authors = [{ name = "Samuel Lobo", email = "samuels.lobo@gmail.com" }]
 description = "Run FastHydroMap from ChimeraX and color structures by predicted Fdewet or PC maps"
 dependencies = [
-  "ChimeraX-Core ~=1.0",
+  "ChimeraX-Core ~=1.12",
   "ChimeraX-Atomic >=1.66",
   "ChimeraX-PDB >=2.0",
   "ChimeraX-Surface >=1.0",

--- a/src/bundles/fasthydromap/src/__init__.py
+++ b/src/bundles/fasthydromap/src/__init__.py
@@ -1,17 +1,9 @@
-# === UCSF ChimeraX Copyright ===
-# Copyright 2026 Regents of the University of California.
-# All rights reserved.  This software provided pursuant to a
-# license agreement containing restrictions on its disclosure,
-# duplication and use.  For details see:
-# https://www.rbvi.ucsf.edu/chimerax/docs/licensing.html
-# This notice must be embedded in or attached to all copies,
-# including partial copies, of the software or any revisions
-# or derivations thereof.
-# === UCSF ChimeraX Copyright ===
+# SPDX-License-Identifier: MIT
+# Copyright 2026 Samuel Lobo
 
 from chimerax.core.toolshed import BundleAPI
 
-__version__ = "0.1"
+__version__ = "0.1.0"
 
 
 class _FastHydroMapAPI(BundleAPI):

--- a/src/bundles/fasthydromap/src/__init__.py
+++ b/src/bundles/fasthydromap/src/__init__.py
@@ -3,7 +3,7 @@
 
 from chimerax.core.toolshed import BundleAPI
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
 
 class _FastHydroMapAPI(BundleAPI):

--- a/src/bundles/fasthydromap/src/__init__.py
+++ b/src/bundles/fasthydromap/src/__init__.py
@@ -1,0 +1,29 @@
+# === UCSF ChimeraX Copyright ===
+# Copyright 2026 Regents of the University of California.
+# All rights reserved.  This software provided pursuant to a
+# license agreement containing restrictions on its disclosure,
+# duplication and use.  For details see:
+# https://www.rbvi.ucsf.edu/chimerax/docs/licensing.html
+# This notice must be embedded in or attached to all copies,
+# including partial copies, of the software or any revisions
+# or derivations thereof.
+# === UCSF ChimeraX Copyright ===
+
+from chimerax.core.toolshed import BundleAPI
+
+__version__ = "0.1"
+
+
+class _FastHydroMapAPI(BundleAPI):
+
+    @staticmethod
+    def register_command(command_name, logger):
+        if command_name == "fasthydromap":
+            from .cmd import register_fasthydromap_command
+            register_fasthydromap_command(logger)
+        elif command_name == "fasthydromap install":
+            from .install import register_fasthydromap_install_command
+            register_fasthydromap_install_command(logger)
+
+
+bundle_api = _FastHydroMapAPI()

--- a/src/bundles/fasthydromap/src/cmd.py
+++ b/src/bundles/fasthydromap/src/cmd.py
@@ -1,13 +1,5 @@
-# === UCSF ChimeraX Copyright ===
-# Copyright 2026 Regents of the University of California.
-# All rights reserved.  This software provided pursuant to a
-# license agreement containing restrictions on its disclosure,
-# duplication and use.  For details see:
-# https://www.rbvi.ucsf.edu/chimerax/docs/licensing.html
-# This notice must be embedded in or attached to all copies,
-# including partial copies, of the software or any revisions
-# or derivations thereof.
-# === UCSF ChimeraX Copyright ===
+# SPDX-License-Identifier: MIT
+# Copyright 2026 Samuel Lobo
 
 import csv
 import os

--- a/src/bundles/fasthydromap/src/cmd.py
+++ b/src/bundles/fasthydromap/src/cmd.py
@@ -1,0 +1,263 @@
+# === UCSF ChimeraX Copyright ===
+# Copyright 2026 Regents of the University of California.
+# All rights reserved.  This software provided pursuant to a
+# license agreement containing restrictions on its disclosure,
+# duplication and use.  For details see:
+# https://www.rbvi.ucsf.edu/chimerax/docs/licensing.html
+# This notice must be embedded in or attached to all copies,
+# including partial copies, of the software or any revisions
+# or derivations thereof.
+# === UCSF ChimeraX Copyright ===
+
+import csv
+import os
+import re
+import subprocess
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from chimerax.core.errors import UserError
+
+from .install import managed_fasthydromap_executable
+
+ATTR_NAME = "fasthydromap_score"
+DEFAULT_PALETTE = "^lipophilicity"
+DEFAULT_RANGE = "4,6.5"
+
+
+def fasthydromap(
+    session,
+    structures=None,
+    *,
+    color=True,
+    target="acs",
+    show_atoms=None,
+    install_location=None,
+):
+    from chimerax.atomic import Residue, all_atomic_structures
+
+    if structures is None:
+        structures = list(all_atomic_structures(session))
+    else:
+        structures = list(structures)
+
+    if not structures:
+        raise UserError("fasthydromap: no atomic structures specified")
+
+    Residue.register_attr(session, ATTR_NAME, "FastHydroMap", attr_type=float)
+
+    colored = 0
+    for structure in structures:
+        assigned = _assign_fasthydromap_scores(
+            session,
+            structure,
+            install_location=install_location,
+        )
+        if assigned == 0:
+            session.logger.warning(f"FastHydroMap assigned no residues for {structure}")
+            continue
+        colored += 1
+        if color:
+            _color_structure(session, structure, target=target, show_atoms=show_atoms)
+
+    if colored == 0:
+        raise UserError("fasthydromap: no structures produced usable FastHydroMap predictions")
+
+
+def _assign_fasthydromap_scores(session, structure, *, install_location):
+    scores = _predict_scores(
+        session,
+        structure,
+        install_location=install_location,
+    )
+    if not scores:
+        return 0
+
+    no_chain_lookup = {}
+    for residue in structure.residues:
+        label = _residue_label(residue, include_chain=False)
+        if label is not None and label not in no_chain_lookup:
+            no_chain_lookup[label] = residue
+
+    assigned = 0
+    for residue_label, score in scores.items():
+        residue = _find_structure_residue(structure, residue_label, no_chain_lookup)
+        if residue is None:
+            session.logger.warning(
+                f"FastHydroMap could not map prediction {residue_label} onto {structure}"
+            )
+            continue
+        setattr(residue, ATTR_NAME, float(score))
+        assigned += 1
+
+    session.logger.info(f"FastHydroMap assigned {assigned} residues for {structure}")
+    return assigned
+
+
+def _predict_scores(session, structure, *, install_location):
+    with TemporaryDirectory(prefix="fasthydromap_") as temp_dir:
+        temp_path = Path(temp_dir)
+        pdb_path = temp_path / "model.pdb"
+        outroot = temp_path / "fasthydromap"
+        csv_path = Path(f"{outroot}.csv")
+
+        from chimerax.pdb import save_pdb
+        save_pdb(session, str(pdb_path), models=[structure])
+
+        command = _fasthydromap_command(
+            session,
+            pdb_path,
+            outroot,
+            install_location=install_location,
+        )
+        try:
+            proc = subprocess.run(
+                command,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                check=True,
+            )
+        except FileNotFoundError as err:
+            raise UserError(
+                "fasthydromap: could not find the FastHydroMap executable. "
+                "Run 'fasthydromap install' or set FASTHYDROMAP_EXE."
+            ) from err
+        except subprocess.CalledProcessError as err:
+            stderr = (err.stderr or "").strip()
+            stdout = (err.stdout or "").strip()
+            detail = stderr or stdout or str(err)
+            raise UserError(f"fasthydromap failed for {structure}: {detail}") from err
+
+        if not csv_path.exists():
+            detail = (proc.stderr or proc.stdout or "").strip()
+            raise UserError(
+                f"fasthydromap did not produce {csv_path.name} for {structure}: {detail}"
+            )
+        return _read_single_structure_scores(csv_path)
+
+
+def _fasthydromap_command(session, pdb_path, outroot, *, install_location):
+    exe_override = os.environ.get("FASTHYDROMAP_EXE")
+    if exe_override:
+        return [exe_override, "predict", str(pdb_path), "-o", str(outroot)]
+
+    managed_exe = managed_fasthydromap_executable(session, install_location=install_location)
+    if managed_exe:
+        return [managed_exe, "predict", str(pdb_path), "-o", str(outroot)]
+
+    raise UserError(
+        "FastHydroMap is not installed in ChimeraX yet. "
+        "Run 'fasthydromap install' first, or set FASTHYDROMAP_EXE."
+    )
+
+
+def _read_single_structure_scores(csv_path):
+    with open(csv_path, newline="") as f:
+        rows = list(csv.reader(f))
+    if len(rows) < 2:
+        raise UserError(f"fasthydromap output {csv_path} is missing prediction rows")
+
+    header = rows[0]
+    if header and header[0] == "frame":
+        values = rows[1]
+        if len(header) != len(values):
+            raise UserError(f"fasthydromap output {csv_path} has inconsistent column counts")
+        return {label: float(score) for label, score in zip(header[1:], values[1:])}
+
+    if "residue" in header and "Fdewet" in header:
+        residue_index = header.index("residue")
+        score_index = header.index("Fdewet")
+        scores = {}
+        for row in rows[1:]:
+            if len(row) <= max(residue_index, score_index):
+                raise UserError(f"fasthydromap output {csv_path} has inconsistent column counts")
+            scores[row[residue_index]] = float(row[score_index])
+        return scores
+
+    raise UserError(f"fasthydromap output {csv_path} has an unexpected header")
+
+
+def _color_structure(session, structure, *, target, show_atoms):
+    from chimerax.core.commands import run
+
+    spec = structure.atomspec
+    if "s" in target:
+        run(session, f"show {spec} surface")
+    if "c" in target:
+        run(session, f"show {spec} cartoon")
+    if show_atoms is None:
+        show_atoms = "s" not in target
+    if show_atoms:
+        run(session, f"show {spec} atoms")
+        run(session, f"show {spec} bonds")
+    else:
+        run(session, f"hide {spec} atoms")
+    run(
+        session,
+        f"color byattribute r:{ATTR_NAME} {spec} target {target} palette {DEFAULT_PALETTE}"
+            f" range {DEFAULT_RANGE}"
+            f" novalue gray",
+    )
+
+
+def _find_structure_residue(structure, residue_label, no_chain_lookup):
+    chain_id, resid, insertion_code = _parse_residue_label(residue_label)
+    if chain_id is None:
+        return no_chain_lookup.get(f"{resid}{insertion_code}")
+    insert = insertion_code or " "
+    return structure.find_residue(chain_id, resid, insert=insert)
+
+
+def _parse_residue_label(label):
+    if ":" in label:
+        chain_id, base = label.split(":", 1)
+        chain_id = chain_id if chain_id != "_" else " "
+    else:
+        chain_id = None
+        base = label
+    match = re.match(r"(-?\d+)(.*)$", base)
+    if match is None:
+        raise UserError(f"fasthydromap returned an unrecognized residue label: {label}")
+    resid = int(match.group(1))
+    insertion_code = match.group(2).strip()
+    return chain_id, resid, insertion_code
+
+
+def _residue_label(residue, *, include_chain):
+    if residue.polymer_type != residue.PT_AMINO:
+        return None
+    atom_names = {a.name for a in residue.atoms}
+    if not {"N", "CA", "C"}.issubset(atom_names):
+        return None
+    base = f"{residue.number}{residue.insertion_code.strip()}"
+    if include_chain:
+        chain_id = residue.chain_id.strip() or "_"
+        return f"{chain_id}:{base}"
+    return base
+
+
+def register_fasthydromap_command(logger):
+    from chimerax.core.commands import (
+        BoolArg,
+        CmdDesc,
+        Or,
+        EmptyArg,
+        SaveFolderNameArg,
+        register,
+    )
+    from chimerax.atomic import AtomicStructuresArg
+    from chimerax.std_commands.color import TargetArg
+
+    desc = CmdDesc(
+        required=[("structures", Or(AtomicStructuresArg, EmptyArg))],
+        keyword=[
+            ("color", BoolArg),
+            ("target", TargetArg),
+            ("show_atoms", BoolArg),
+            ("install_location", SaveFolderNameArg),
+        ],
+        synopsis="Predict per-residue Fdewet with FastHydroMap and optionally color the result",
+    )
+    register("fasthydromap", desc, fasthydromap, logger=logger)

--- a/src/bundles/fasthydromap/src/cmd.py
+++ b/src/bundles/fasthydromap/src/cmd.py
@@ -20,9 +20,32 @@ from chimerax.core.errors import UserError
 
 from .install import managed_fasthydromap_executable
 
-ATTR_NAME = "fasthydromap_score"
-DEFAULT_PALETTE = "^lipophilicity"
-DEFAULT_RANGE = "4,6.5"
+QUANTITY_SPECS = {
+    "fdewet": {
+        "label": "Fdewet",
+        "attr": "fasthydromap_fdewet",
+        "palette": "^lipophilicity",
+        "range": (4.0, 6.5),
+    },
+    "pc1": {
+        "label": "PC1",
+        "attr": "fasthydromap_pc1",
+        "palette": "red-white-blue",
+        "range": (-8.0, 8.0),
+    },
+    "pc2": {
+        "label": "PC2",
+        "attr": "fasthydromap_pc2",
+        "palette": "cyanmaroon",
+        "range": (-2.0, 8.0),
+    },
+    "pc3": {
+        "label": "PC3",
+        "attr": "fasthydromap_pc3",
+        "palette": "^lipophilicity",
+        "range": (-2.0, 2.0),
+    },
+}
 
 
 def fasthydromap(
@@ -32,9 +55,17 @@ def fasthydromap(
     color=True,
     target="acs",
     show_atoms=None,
+    quantity="fdewet",
+    palette=None,
+    range=None,
     install_location=None,
 ):
     from chimerax.atomic import Residue, all_atomic_structures
+    quantity = quantity.lower()
+    if quantity not in QUANTITY_SPECS:
+        raise UserError(f"fasthydromap: unknown quantity {quantity!r}")
+    spec = QUANTITY_SPECS[quantity]
+    attr_name = spec["attr"]
 
     if structures is None:
         structures = list(all_atomic_structures(session))
@@ -44,13 +75,15 @@ def fasthydromap(
     if not structures:
         raise UserError("fasthydromap: no atomic structures specified")
 
-    Residue.register_attr(session, ATTR_NAME, "FastHydroMap", attr_type=float)
+    Residue.register_attr(session, attr_name, "FastHydroMap", attr_type=float)
 
     colored = 0
     for structure in structures:
         assigned = _assign_fasthydromap_scores(
             session,
             structure,
+            quantity=quantity,
+            attr_name=attr_name,
             install_location=install_location,
         )
         if assigned == 0:
@@ -58,16 +91,25 @@ def fasthydromap(
             continue
         colored += 1
         if color:
-            _color_structure(session, structure, target=target, show_atoms=show_atoms)
+            _color_structure(
+                session,
+                structure,
+                target=target,
+                show_atoms=show_atoms,
+                attr_name=attr_name,
+                palette=spec["palette"] if palette is None else palette,
+                color_range=spec["range"] if range is None else range,
+            )
 
     if colored == 0:
         raise UserError("fasthydromap: no structures produced usable FastHydroMap predictions")
 
 
-def _assign_fasthydromap_scores(session, structure, *, install_location):
+def _assign_fasthydromap_scores(session, structure, *, quantity, attr_name, install_location):
     scores = _predict_scores(
         session,
         structure,
+        quantity=quantity,
         install_location=install_location,
     )
     if not scores:
@@ -87,14 +129,16 @@ def _assign_fasthydromap_scores(session, structure, *, install_location):
                 f"FastHydroMap could not map prediction {residue_label} onto {structure}"
             )
             continue
-        setattr(residue, ATTR_NAME, float(score))
+        setattr(residue, attr_name, float(score))
         assigned += 1
 
-    session.logger.info(f"FastHydroMap assigned {assigned} residues for {structure}")
+    session.logger.info(
+        f"FastHydroMap assigned {assigned} {QUANTITY_SPECS[quantity]['label']} residues for {structure}"
+    )
     return assigned
 
 
-def _predict_scores(session, structure, *, install_location):
+def _predict_scores(session, structure, *, quantity, install_location):
     with TemporaryDirectory(prefix="fasthydromap_") as temp_dir:
         temp_path = Path(temp_dir)
         pdb_path = temp_path / "model.pdb"
@@ -108,6 +152,7 @@ def _predict_scores(session, structure, *, install_location):
             session,
             pdb_path,
             outroot,
+            quantity=quantity,
             install_location=install_location,
         )
         try:
@@ -135,17 +180,17 @@ def _predict_scores(session, structure, *, install_location):
             raise UserError(
                 f"fasthydromap did not produce {csv_path.name} for {structure}: {detail}"
             )
-        return _read_single_structure_scores(csv_path)
+        return _read_single_structure_scores(csv_path, quantity=quantity)
 
 
-def _fasthydromap_command(session, pdb_path, outroot, *, install_location):
+def _fasthydromap_command(session, pdb_path, outroot, *, quantity, install_location):
     exe_override = os.environ.get("FASTHYDROMAP_EXE")
     if exe_override:
-        return [exe_override, "predict", str(pdb_path), "-o", str(outroot)]
+        return [exe_override, "predict", str(pdb_path), "-o", str(outroot), "--quantity", quantity]
 
     managed_exe = managed_fasthydromap_executable(session, install_location=install_location)
     if managed_exe:
-        return [managed_exe, "predict", str(pdb_path), "-o", str(outroot)]
+        return [managed_exe, "predict", str(pdb_path), "-o", str(outroot), "--quantity", quantity]
 
     raise UserError(
         "FastHydroMap is not installed in ChimeraX yet. "
@@ -153,7 +198,7 @@ def _fasthydromap_command(session, pdb_path, outroot, *, install_location):
     )
 
 
-def _read_single_structure_scores(csv_path):
+def _read_single_structure_scores(csv_path, *, quantity="fdewet"):
     with open(csv_path, newline="") as f:
         rows = list(csv.reader(f))
     if len(rows) < 2:
@@ -166,9 +211,10 @@ def _read_single_structure_scores(csv_path):
             raise UserError(f"fasthydromap output {csv_path} has inconsistent column counts")
         return {label: float(score) for label, score in zip(header[1:], values[1:])}
 
-    if "residue" in header and "Fdewet" in header:
+    score_column = QUANTITY_SPECS[quantity]["label"]
+    if "residue" in header and score_column in header:
         residue_index = header.index("residue")
-        score_index = header.index("Fdewet")
+        score_index = header.index(score_column)
         scores = {}
         for row in rows[1:]:
             if len(row) <= max(residue_index, score_index):
@@ -179,8 +225,10 @@ def _read_single_structure_scores(csv_path):
     raise UserError(f"fasthydromap output {csv_path} has an unexpected header")
 
 
-def _color_structure(session, structure, *, target, show_atoms):
+def _color_structure(session, structure, *, target, show_atoms, attr_name, palette, color_range):
+    from chimerax.core.colors import BuiltinColors
     from chimerax.core.commands import run
+    from chimerax.std_commands.color import color_by_attr
 
     spec = structure.atomspec
     if "s" in target:
@@ -194,12 +242,28 @@ def _color_structure(session, structure, *, target, show_atoms):
         run(session, f"show {spec} bonds")
     else:
         run(session, f"hide {spec} atoms")
-    run(
+    color_by_attr(
         session,
-        f"color byattribute r:{ATTR_NAME} {spec} target {target} palette {DEFAULT_PALETTE}"
-            f" range {DEFAULT_RANGE}"
-            f" novalue gray",
+        f"r:{attr_name}",
+        atoms=structure.atoms,
+        target=target,
+        palette=_resolve_palette(palette),
+        range=color_range,
+        no_value_color=BuiltinColors["gray"],
+        log_info=False,
     )
+
+
+def _resolve_palette(palette):
+    if not isinstance(palette, str):
+        return palette
+
+    from chimerax.core.colors import BuiltinColormaps
+
+    reverse = palette.startswith("^")
+    palette_name = palette[1:] if reverse else palette
+    cmap = BuiltinColormaps[palette_name.casefold()]
+    return cmap.reversed() if reverse else cmap
 
 
 def _find_structure_residue(structure, residue_label, no_chain_lookup):
@@ -241,7 +305,10 @@ def _residue_label(residue, *, include_chain):
 def register_fasthydromap_command(logger):
     from chimerax.core.commands import (
         BoolArg,
+        ColormapArg,
+        ColormapRangeArg,
         CmdDesc,
+        EnumOf,
         Or,
         EmptyArg,
         SaveFolderNameArg,
@@ -256,8 +323,11 @@ def register_fasthydromap_command(logger):
             ("color", BoolArg),
             ("target", TargetArg),
             ("show_atoms", BoolArg),
+            ("quantity", EnumOf(tuple(QUANTITY_SPECS))),
+            ("palette", ColormapArg),
+            ("range", ColormapRangeArg),
             ("install_location", SaveFolderNameArg),
         ],
-        synopsis="Predict per-residue Fdewet with FastHydroMap and optionally color the result",
+        synopsis="Predict per-residue Fdewet/PC values with FastHydroMap and optionally color the result",
     )
     register("fasthydromap", desc, fasthydromap, logger=logger)

--- a/src/bundles/fasthydromap/src/cmd.py
+++ b/src/bundles/fasthydromap/src/cmd.py
@@ -39,6 +39,8 @@ QUANTITY_SPECS = {
     },
 }
 
+HISTIDINE_NAMES = frozenset({"HIS", "HID", "HIE", "HIP", "HSD", "HSE", "HSP"})
+
 
 def fasthydromap(
     session,
@@ -65,7 +67,11 @@ def fasthydromap(
         structures = list(structures)
 
     if not structures:
-        raise UserError("fasthydromap: no atomic structures specified")
+        raise UserError(
+            "fasthydromap: no atomic structures specified. Open a protein, for example "
+            "with 'open 1a1u', then run 'fasthydromap #1'. See 'help fasthydromap' "
+            "for more examples."
+        )
 
     Residue.register_attr(session, attr_name, "FastHydroMap", attr_type=float)
 
@@ -137,8 +143,7 @@ def _predict_scores(session, structure, *, quantity, install_location):
         outroot = temp_path / "fasthydromap"
         csv_path = Path(f"{outroot}.csv")
 
-        from chimerax.pdb import save_pdb
-        save_pdb(session, str(pdb_path), models=[structure])
+        _save_protein_only_pdb(session, structure, pdb_path)
 
         command = _fasthydromap_command(
             session,
@@ -173,6 +178,83 @@ def _predict_scores(session, structure, *, quantity, install_location):
                 f"fasthydromap did not produce {csv_path.name} for {structure}: {detail}"
             )
         return _read_single_structure_scores(csv_path, quantity=quantity)
+
+
+def _save_protein_only_pdb(session, structure, pdb_path):
+    """Write a disposable protein-only copy without changing the open model."""
+    residues = list(structure.residues)
+    protein_residues = [
+        residue for residue in residues if residue.polymer_type == residue.PT_AMINO
+    ]
+    nonprotein_residues = [
+        residue for residue in residues if residue.polymer_type != residue.PT_AMINO
+    ]
+    if not protein_residues:
+        raise UserError(f"fasthydromap: {structure} contains no protein residues")
+
+    _warn_prediction_limitations(
+        session,
+        structure,
+        protein_residues=protein_residues,
+        nonprotein_residues=nonprotein_residues,
+    )
+
+    filtered_structure = structure.copy(name=f"{structure.name} FastHydroMap input")
+    try:
+        nonprotein_atoms = [
+            atom
+            for residue in filtered_structure.residues
+            if residue.polymer_type != residue.PT_AMINO
+            for atom in residue.atoms
+        ]
+        if nonprotein_atoms:
+            from chimerax.atomic import Atoms
+
+            Atoms(nonprotein_atoms).delete()
+
+        from chimerax.pdb import save_pdb
+
+        save_pdb(session, str(pdb_path), models=[filtered_structure])
+    finally:
+        filtered_structure.delete()
+
+
+def _warn_prediction_limitations(
+    session, structure, *, protein_residues, nonprotein_residues
+):
+    if nonprotein_residues:
+        session.logger.warning(
+            f"FastHydroMap predicts proteins only; ignoring "
+            f"{len(nonprotein_residues)} non-protein residues in {structure}. DNA, RNA, "
+            "waters, ions, and ligands are not modeled. Ignored residues include: "
+            f"{_residue_preview(nonprotein_residues)}"
+        )
+
+    histidines = [
+        residue
+        for residue in protein_residues
+        if residue.name.strip().upper() in HISTIDINE_NAMES
+    ]
+    if histidines:
+        session.logger.warning(
+            "FastHydroMap assumes neutral histidine chemistry. Histidine tautomer "
+            "assignments such as HID/HIE (or HSD/HSE) and protonated histidine charge "
+            "states such as HIP/HSP are not modeled; interpret predictions cautiously "
+            f"for: {_residue_preview(histidines)}"
+        )
+
+
+def _residue_preview(residues, max_items=10):
+    labels = []
+    for residue in residues:
+        chain_id = residue.chain_id.strip() or "_"
+        insertion_code = residue.insertion_code.strip()
+        labels.append(
+            f"{chain_id}:{residue.number}{insertion_code} {residue.name.strip()}"
+        )
+    if len(labels) > max_items:
+        return ", ".join(labels[:max_items]) + f", ... (+{len(labels) - max_items} more)"
+    return ", ".join(labels)
 
 
 def _fasthydromap_command(session, pdb_path, outroot, *, quantity, install_location):

--- a/src/bundles/fasthydromap/src/docs/user/commands/fasthydromap.html
+++ b/src/bundles/fasthydromap/src/docs/user/commands/fasthydromap.html
@@ -1,0 +1,78 @@
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" type="text/css" href="../userdocs.css">
+<title>Command: fasthydromap</title>
+</head>
+<body>
+
+<a name="top"></a>
+<h3>Command: fasthydromap</h3>
+<p>
+The <b>fasthydromap</b> command predicts per-residue hydrophobicity or
+water-structure values with
+<a href="https://github.com/samlobe/FastHydroMap">FastHydroMap</a>, stores the
+values as ChimeraX residue attributes, and optionally colors the structure.
+</p>
+
+<a name="install"></a>
+<h3>Installation</h3>
+<p>
+Before the first prediction, install FastHydroMap and PyTorch into an isolated,
+bundle-managed Python environment:
+</p>
+<blockquote><b>fasthydromap install</b>
+[ <i>directory</i> ]
+[&nbsp;<b>torchVariant</b>&nbsp;&nbsp;<i>variant</i>&nbsp;]
+[&nbsp;<b>wait</b>&nbsp;&nbsp;true&nbsp;|&nbsp;false&nbsp;]
+</blockquote>
+<p>
+The default installation directory is inside the ChimeraX user data directory,
+and the default Torch variant is <b>cpu</b>. A CUDA-enabled variant supported by
+FastHydroMap, such as <b>cu121</b>, can be requested with <b>torchVariant</b>.
+The installation may take several minutes and requires internet access.
+</p>
+
+<a name="usage"></a>
+<h3>Usage</h3>
+<blockquote><b>fasthydromap</b> <i>structures</i>
+[&nbsp;<b>quantity</b>&nbsp;&nbsp;fdewet&nbsp;|&nbsp;pc1&nbsp;|&nbsp;pc2&nbsp;|&nbsp;pc3&nbsp;]
+[&nbsp;<b>color</b>&nbsp;&nbsp;true&nbsp;|&nbsp;false&nbsp;]
+[&nbsp;<b>target</b>&nbsp;&nbsp;<i>letters</i>&nbsp;]
+[&nbsp;<b>showAtoms</b>&nbsp;&nbsp;true&nbsp;|&nbsp;false&nbsp;]
+[&nbsp;<b>palette</b>&nbsp;&nbsp;<i>palette</i>&nbsp;]
+[&nbsp;<b>range</b>&nbsp;&nbsp;<i>low,high</i>&nbsp;]
+[&nbsp;<b>installLocation</b>&nbsp;&nbsp;<i>directory</i>&nbsp;]
+</blockquote>
+<p>
+If no model is specified, all open atomic structures are processed. The
+<b>quantity</b> defaults to <b>fdewet</b>. The resulting residue attributes are
+named <b>fasthydromap_fdewet</b>, <b>fasthydromap_pc1</b>,
+<b>fasthydromap_pc2</b>, and <b>fasthydromap_pc3</b>.
+</p>
+<p>
+The <b>target</b> letters select atoms (<b>a</b>), cartoons (<b>c</b>), and
+surfaces (<b>s</b>); the default is <b>acs</b>. Each quantity has a scientifically
+chosen default palette and numeric range, which can be overridden with
+<b>palette</b> and <b>range</b>.
+</p>
+
+<a name="examples"></a>
+<h3>Examples</h3>
+<blockquote>
+<b>fasthydromap #1</b><br>
+Predict Fdewet for model #1 and color its atoms, cartoon, and surface.
+</blockquote>
+<blockquote>
+<b>fasthydromap #1 quantity pc1 target cs</b><br>
+Predict PC1 and color only the cartoon and surface.
+</blockquote>
+<blockquote>
+<b>fasthydromap #1 quantity pc2 palette blue:white:red range -2,8</b><br>
+Predict PC2 using a custom color palette and range.
+</blockquote>
+
+<hr>
+<address>FastHydroMap / August 2026</address>
+</body>
+</html>

--- a/src/bundles/fasthydromap/src/docs/user/commands/fasthydromap.html
+++ b/src/bundles/fasthydromap/src/docs/user/commands/fasthydromap.html
@@ -13,6 +13,23 @@ The <b>fasthydromap</b> command predicts per-residue hydrophobicity or
 water-structure values with
 <a href="https://github.com/samlobe/FastHydroMap">FastHydroMap</a>, stores the
 values as ChimeraX residue attributes, and optionally colors the structure.
+Only amino-acid polymer residues are sent to FastHydroMap. Nucleic acids,
+waters, ions, and ligands remain in the open model but are excluded from the
+temporary prediction input. A warning in the Log lists examples of ignored
+residues.
+</p>
+<p>
+FastHydroMap assumes neutral histidine chemistry. It does not distinguish
+HID/HIE (or HSD/HSE) tautomer assignments and does not represent the positive
+charge of HIP/HSP. A warning is shown for structures containing histidine.
+</p>
+<p>
+Unlike sequence hydropathy scales that assign one value to each amino-acid
+identity, Fdewet is a context-dependent thermodynamic measure of how readily
+water can be removed from a local surface. Lower Fdewet is more hydrophobic;
+higher Fdewet is more hydrophilic. See the
+<a href="https://doi.org/10.64898/2026.06.07.730647">HydroMap and FastHydroMap paper</a>
+for the method and applications.
 </p>
 
 <a name="install"></a>
@@ -30,7 +47,9 @@ bundle-managed Python environment:
 The default installation directory is inside the ChimeraX user data directory,
 and the default Torch variant is <b>cpu</b>. A CUDA-enabled variant supported by
 FastHydroMap, such as <b>cu121</b>, can be requested with <b>torchVariant</b>.
-The installation may take several minutes and requires internet access.
+The installation may take several minutes and requires internet access. When it
+finishes, the Log shows clickable commands for a first prediction and this help
+page.
 </p>
 
 <a name="usage"></a>
@@ -51,10 +70,32 @@ named <b>fasthydromap_fdewet</b>, <b>fasthydromap_pc1</b>,
 <b>fasthydromap_pc2</b>, and <b>fasthydromap_pc3</b>.
 </p>
 <p>
-The <b>target</b> letters select atoms (<b>a</b>), cartoons (<b>c</b>), and
-surfaces (<b>s</b>); the default is <b>acs</b>. Each quantity has a scientifically
-chosen default palette and numeric range, which can be overridden with
-<b>palette</b> and <b>range</b>.
+Each quantity has a scientifically chosen default palette and numeric range.
+These defaults are intended for normal use. The <b>palette</b> and <b>range</b>
+options customize the color scale, while <b>target</b> and <b>showAtoms</b>
+provide additional display-only control.
+</p>
+
+<a name="interpretation"></a>
+<h3>Interpretation</h3>
+<table border="1" cellpadding="4" cellspacing="0">
+<tr><th>Map</th><th>Negative or low values</th><th>Positive or high values</th></tr>
+<tr><td><b>Fdewet</b></td><td>Easier to remove water; more hydrophobic</td>
+<td>Water retained more strongly; more hydrophilic</td></tr>
+<tr><td><b>PC1</b></td><td>More tetrahedral water ordering; generally more hydrophobic</td>
+<td>Shift toward simple-fluid/icosahedral motifs</td></tr>
+<tr><td><b>PC2</b></td><td>Enrichment around 125&ndash;150&deg; and depletion around 80&ndash;105&deg;</td>
+<td>Enrichment around 80&ndash;105&deg; (maximum loading at 92.5&deg;) and depletion around
+120&ndash;150&deg;; disordered water associated with large, smooth hydrophobic interfaces</td></tr>
+<tr><td><b>PC3</b></td><td>Depleted high-coordination water signature</td>
+<td>More highly coordinated water near polar/charged sites; generally more hydrophilic</td></tr>
+</table>
+<p>
+PC1-PC3 are signed water-structure descriptors, not energy scales. PC2 is
+particularly sensitive to surface geometry. Its positive, roughly
+90&deg;-centered signature can be called disordered, simple-fluid-like, or
+vapor-interface-like, but it is not a literal ideal-gas order parameter. It
+should be interpreted alongside Fdewet and the structure.
 </p>
 
 <a name="examples"></a>
@@ -64,13 +105,20 @@ chosen default palette and numeric range, which can be overridden with
 Predict Fdewet for model #1 and color its atoms, cartoon, and surface.
 </blockquote>
 <blockquote>
-<b>fasthydromap #1 quantity pc1 target cs</b><br>
-Predict PC1 and color only the cartoon and surface.
+<b>fasthydromap #1 quantity pc1</b><br>
+Predict PC1 and color the structure with its default palette and range.
 </blockquote>
 <blockquote>
 <b>fasthydromap #1 quantity pc2 palette blue:white:red range -2,8</b><br>
 Predict PC2 using a custom color palette and range.
 </blockquote>
+<a name="tutorial"></a>
+<h3>Tutorial</h3>
+<p>
+The complete walkthrough, including installation, the motivation for Fdewet,
+water-structure sign conventions, and palette controls, is available in the
+<a href="https://github.com/samlobe/FastHydroMap/blob/main/docs/ChimeraX_tutorial.md">FastHydroMap ChimeraX tutorial</a>.
+</p>
 
 <hr>
 <address>FastHydroMap / August 2026</address>

--- a/src/bundles/fasthydromap/src/install.py
+++ b/src/bundles/fasthydromap/src/install.py
@@ -1,0 +1,284 @@
+from os.path import exists, expanduser, isdir, join
+
+from chimerax.core.errors import UserError
+
+from .settings import _fasthydromap_settings
+
+
+DEFAULT_PACKAGE_SPEC = "fasthydromap"
+DEFAULT_TORCH_VARIANT = "cpu"
+
+
+def fasthydromap_install(
+    session,
+    directory=None,
+    *,
+    wait=None,
+    torch_variant=DEFAULT_TORCH_VARIANT,
+    package_spec=DEFAULT_PACKAGE_SPEC,
+):
+    if directory is None:
+        from chimerax import app_dirs
+
+        directory = join(app_dirs.user_data_dir, "fasthydromap")
+    else:
+        directory = expanduser(directory)
+
+    if wait is None:
+        wait = False if session.ui.is_gui else True
+
+    return InstallFastHydroMap(
+        session,
+        directory,
+        package_spec=package_spec,
+        torch_variant=torch_variant,
+        wait=wait,
+    )
+
+
+class InstallFastHydroMap:
+    def __init__(self, session, directory, *, package_spec, torch_variant, wait):
+        self._session = session
+        self._directory = directory
+        self._package_spec = package_spec
+        self._torch_variant = torch_variant
+        self._wait = wait
+        self.finished_callback = None
+        self.success = None
+
+        self._check_install_directory()
+        if self._create_virtual_environment():
+            self._upgrade_packaging_tools()
+
+    def _check_install_directory(self):
+        if exists(self._directory):
+            from os import listdir
+
+            if not isdir(self._directory) or listdir(self._directory):
+                raise UserError(
+                    "You must install FastHydroMap into a new or empty directory. "
+                    f"The directory {self._directory} already exists and is not empty."
+                )
+
+    def _create_virtual_environment(self):
+        from chimerax.core.python_utils import chimerax_python_executable
+        from subprocess import run
+
+        python_exe = chimerax_python_executable()
+        command = [python_exe, "-m", "venv", self._directory]
+        p = run(command, capture_output=True, text=True, encoding="utf-8", errors="replace",
+                creationflags=_no_subprocess_window())
+
+        logger = self._session.logger
+        if p.returncode == 0:
+            logger.info(f"Successfully created FastHydroMap Python virtual environment {self._directory}.")
+            return True
+
+        logger.error(
+            "Creating FastHydroMap Python virtual environment failed."
+            f"\nCommand: {' '.join(command)}"
+            f"\nstdout: {p.stdout}"
+            f"\nstderr: {p.stderr}"
+        )
+        self._finished("create environment", success=False)
+        return False
+
+    def _venv_python_executable(self):
+        return find_executable(self._directory, "python")
+
+    def _fasthydromap_executable(self):
+        return find_executable(self._directory, "fasthydromap")
+
+    def _upgrade_packaging_tools(self):
+        logger = self._session.logger
+        logger.info("Upgrading pip/setuptools/wheel in the FastHydroMap environment.")
+        command = [
+            self._venv_python_executable(),
+            "-m",
+            "pip",
+            "install",
+            "--upgrade",
+            "pip",
+            "setuptools<81",
+            "wheel",
+        ]
+        log_subprocess_output(self._session, command, self._finished_upgrade_packaging_tools, wait=self._wait)
+
+    def _finished_upgrade_packaging_tools(self, success):
+        if success:
+            self._install_fasthydromap_package()
+        else:
+            self._session.logger.error("Failed to upgrade packaging tools for FastHydroMap.")
+            self._finished("upgrade packaging tools", success=False)
+
+    def _install_fasthydromap_package(self):
+        logger = self._session.logger
+        logger.info(f"Installing FastHydroMap package {self._package_spec} from PyPI.")
+        command = [
+            self._venv_python_executable(),
+            "-m",
+            "pip",
+            "install",
+            self._package_spec,
+        ]
+        log_subprocess_output(
+            self._session,
+            command,
+            self._finished_install_fasthydromap_package,
+            wait=self._wait,
+        )
+
+    def _finished_install_fasthydromap_package(self, success):
+        if success:
+            self._install_torch()
+        else:
+            self._session.logger.error("Failed to install FastHydroMap from PyPI.")
+            self._finished("install package", success=False)
+
+    def _install_torch(self):
+        logger = self._session.logger
+        logger.info(
+            f"Installing Torch into the managed FastHydroMap environment using variant "
+            f"{self._torch_variant}."
+        )
+        command = [
+            self._fasthydromap_executable(),
+            "install-torch",
+            "--variant",
+            self._torch_variant,
+        ]
+        log_subprocess_output(
+            self._session,
+            command,
+            self._finished_install_torch,
+            wait=self._wait,
+        )
+
+    def _finished_install_torch(self, success):
+        if success:
+            self._finalize_install()
+        else:
+            self._session.logger.error("Failed to install Torch for FastHydroMap.")
+            self._finished("install torch", success=False)
+
+    def _finalize_install(self):
+        self._finish_install(success=True)
+
+    def _finish_install(self, success):
+        logger = self._session.logger
+        if success:
+            settings = _fasthydromap_settings(self._session)
+            settings.fasthydromap_install_location = self._directory
+            settings.save()
+
+            exe = self._fasthydromap_executable()
+            if exists(exe):
+                logger.info(f"FastHydroMap executable installed at {exe}")
+                self._finished("install package", success=True)
+                return
+
+            logger.error(
+                "FastHydroMap package installed, but the fasthydromap executable was not found "
+                f"in {self._directory}."
+            )
+        else:
+            logger.error("FastHydroMap installation failed.  See ChimeraX Log for details.")
+
+        self._finished("install package", success=False)
+
+    def _finished(self, task_name, success=True):
+        if success:
+            self._session.logger.info("Successfully installed FastHydroMap in a managed ChimeraX environment.")
+        self.success = success
+        if self.finished_callback:
+            self.finished_callback(success)
+
+
+class log_subprocess_output:
+    def __init__(self, session, command, finished_callback, wait=False):
+        self._session = session
+
+        from subprocess import PIPE, STDOUT, Popen
+
+        popen = Popen(command, stdout=PIPE, stderr=STDOUT, creationflags=_no_subprocess_window())
+        self._popen = popen
+
+        self._finished_callback = finished_callback
+        from queue import Queue
+        from threading import Thread
+
+        self._queue = Queue()
+        self._thread = t = Thread(target=self._queue_output_in_thread, daemon=True)
+        t.start()
+        if wait:
+            while t.is_alive():
+                self._log_queued_lines()
+            self._finished()
+        else:
+            session.triggers.add_handler("new frame", self._log_queued_lines_while_alive)
+
+    def _queue_output_in_thread(self):
+        while True:
+            line = self._popen.stdout.readline()
+            if not line:
+                break
+            self._queue.put(line)
+
+    def _log_queued_lines(self):
+        while not self._queue.empty():
+            line = self._queue.get()
+            self._session.logger.info(line.decode("utf-8", errors="replace").rstrip())
+
+    def _log_queued_lines_while_alive(self, *trigger_args):
+        self._log_queued_lines()
+        if not self._thread.is_alive():
+            self._finished()
+            return "delete handler"
+
+    def _finished(self):
+        self._popen.wait()
+        success = self._popen.returncode == 0
+        self._finished_callback(success)
+
+def managed_fasthydromap_executable(session, install_location=None):
+    location = install_location
+    if location is None:
+        settings = _fasthydromap_settings(session)
+        location = settings.fasthydromap_install_location
+    if not location:
+        return None
+    exe = find_executable(location, "fasthydromap")
+    return exe if exists(exe) else None
+
+
+def find_executable(venv_directory, exe_name):
+    from sys import platform
+
+    if platform == "win32":
+        return join(venv_directory, "Scripts", exe_name + ".exe")
+    return join(venv_directory, "bin", exe_name)
+
+
+def _no_subprocess_window():
+    from sys import platform
+
+    if platform == "win32":
+        from subprocess import CREATE_NO_WINDOW
+
+        return CREATE_NO_WINDOW
+    return 0
+
+
+def register_fasthydromap_install_command(logger):
+    from chimerax.core.commands import BoolArg, CmdDesc, SaveFolderNameArg, StringArg, register
+
+    desc = CmdDesc(
+        optional=[("directory", SaveFolderNameArg)],
+        keyword=[
+            ("wait", BoolArg),
+            ("torch_variant", StringArg),
+            ("package_spec", StringArg),
+        ],
+        synopsis="Install FastHydroMap from PyPI in a managed ChimeraX virtual environment",
+    )
+    register("fasthydromap install", desc, fasthydromap_install, logger=logger)

--- a/src/bundles/fasthydromap/src/install.py
+++ b/src/bundles/fasthydromap/src/install.py
@@ -68,6 +68,14 @@ class InstallFastHydroMap:
         from subprocess import run
 
         python_exe = chimerax_python_executable()
+        if _is_macos_app_translocation(python_exe):
+            self._session.logger.error(
+                "Cannot install FastHydroMap while ChimeraX is running from a temporary "
+                "macOS App Translocation path. Install ChimeraX in Applications with Finder, "
+                "quit ChimeraX, relaunch the installed app, and run 'fasthydromap install' again."
+            )
+            self._finished("create environment", success=False)
+            return False
         command = [python_exe, "-m", "venv", self._directory]
         p = run(command, capture_output=True, text=True, encoding="utf-8", errors="replace",
                 creationflags=_no_subprocess_window())
@@ -270,6 +278,12 @@ def _no_subprocess_window():
 
         return CREATE_NO_WINDOW
     return 0
+
+
+def _is_macos_app_translocation(executable):
+    from sys import platform
+
+    return platform == "darwin" and "/AppTranslocation/" in executable
 
 
 def register_fasthydromap_install_command(logger):

--- a/src/bundles/fasthydromap/src/install.py
+++ b/src/bundles/fasthydromap/src/install.py
@@ -8,7 +8,7 @@ from chimerax.core.errors import UserError
 from .settings import _fasthydromap_settings
 
 
-DEFAULT_PACKAGE_SPEC = "fasthydromap>=0.1.3,<0.2"
+DEFAULT_PACKAGE_SPEC = "fasthydromap>=0.1.4,<0.2"
 DEFAULT_TORCH_VARIANT = "cpu"
 
 
@@ -199,7 +199,7 @@ class InstallFastHydroMap:
 
     def _finished(self, task_name, success=True):
         if success:
-            self._session.logger.info("Successfully installed FastHydroMap in a managed ChimeraX environment.")
+            _log_ready_message(self._session)
         self.success = success
         if self.finished_callback:
             self.finished_callback(success)
@@ -284,6 +284,21 @@ def _is_macos_app_translocation(executable):
     from sys import platform
 
     return platform == "darwin" and "/AppTranslocation/" in executable
+
+
+def _log_ready_message(session):
+    session.logger.info(
+        "<b>FastHydroMap is ready.</b><br>"
+        "Try: "
+        '<a href="cxcmd:open 1a1u">open 1a1u</a>, then '
+        '<a href="cxcmd:fasthydromap #1">fasthydromap #1</a>.<br>'
+        "Explore water structure with "
+        '<a href="cxcmd:fasthydromap #1 quantity pc1">'
+        "fasthydromap #1 quantity pc1</a>, or open "
+        '<a href="cxcmd:help fasthydromap">help fasthydromap</a> '
+        "for examples and interpretation.",
+        is_html=True,
+    )
 
 
 def register_fasthydromap_install_command(logger):

--- a/src/bundles/fasthydromap/src/install.py
+++ b/src/bundles/fasthydromap/src/install.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: MIT
+# Copyright 2026 Samuel Lobo
+
 from os.path import exists, expanduser, isdir, join
 
 from chimerax.core.errors import UserError
@@ -5,7 +8,7 @@ from chimerax.core.errors import UserError
 from .settings import _fasthydromap_settings
 
 
-DEFAULT_PACKAGE_SPEC = "fasthydromap"
+DEFAULT_PACKAGE_SPEC = "fasthydromap>=0.1.3,<0.2"
 DEFAULT_TORCH_VARIANT = "cpu"
 
 

--- a/src/bundles/fasthydromap/src/settings.py
+++ b/src/bundles/fasthydromap/src/settings.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: MIT
+# Copyright 2026 Samuel Lobo
+
 from chimerax.core.settings import Settings
 
 

--- a/src/bundles/fasthydromap/src/settings.py
+++ b/src/bundles/fasthydromap/src/settings.py
@@ -1,0 +1,15 @@
+from chimerax.core.settings import Settings
+
+
+class _FastHydroMapSettings(Settings):
+    EXPLICIT_SAVE = {
+        "fasthydromap_install_location": "",
+    }
+
+
+def _fasthydromap_settings(session):
+    settings = getattr(session, "_fasthydromap_settings", None)
+    if settings is None:
+        settings = _FastHydroMapSettings(session, "fasthydromap")
+        session._fasthydromap_settings = settings
+    return settings

--- a/src/bundles/fasthydromap/tests/test_fasthydromap.py
+++ b/src/bundles/fasthydromap/tests/test_fasthydromap.py
@@ -340,7 +340,7 @@ def test_install_command_uses_pypi_and_cli_torch(monkeypatch):
     installer = install_module.InstallFastHydroMap.__new__(install_module.InstallFastHydroMap)
     installer._session = session
     installer._directory = "/tmp/fhm"
-    installer._package_spec = "fasthydromap"
+    installer._package_spec = "fasthydromap>=0.1.3,<0.2"
     installer._torch_variant = "cpu"
     installer._wait = True
 
@@ -350,6 +350,12 @@ def test_install_command_uses_pypi_and_cli_torch(monkeypatch):
 
     assert recorded == [
         ["/tmp/fhm/bin/python", "-m", "pip", "install", "--upgrade", "pip", "setuptools<81", "wheel"],
-        ["/tmp/fhm/bin/python", "-m", "pip", "install", "fasthydromap"],
+        [
+            "/tmp/fhm/bin/python",
+            "-m",
+            "pip",
+            "install",
+            "fasthydromap>=0.1.3,<0.2",
+        ],
         ["/tmp/fhm/bin/fasthydromap", "install-torch", "--variant", "cpu"],
     ]

--- a/src/bundles/fasthydromap/tests/test_fasthydromap.py
+++ b/src/bundles/fasthydromap/tests/test_fasthydromap.py
@@ -22,6 +22,9 @@ def test_bundle_metadata_release_constraints():
         for classifier in metadata["tool"]["chimerax"]["classifiers"]
     )
 
+    init_text = (BUNDLE_SRC / "__init__.py").read_text(encoding="utf-8")
+    assert '__version__ = "0.1.1"' in init_text
+
 
 def _stub_chimerax_modules(monkeypatch):
     for name in list(sys.modules):
@@ -163,6 +166,20 @@ def test_fasthydromap_command_requires_install(monkeypatch):
         )
 
 
+def test_fasthydromap_without_open_structure_shows_quick_start(monkeypatch):
+    cmd_module = _load_submodule(monkeypatch, "cmd")
+    atomic = types.ModuleType("chimerax.atomic")
+    atomic.Residue = object
+    atomic.all_atomic_structures = lambda session: []
+    monkeypatch.setitem(sys.modules, "chimerax.atomic", atomic)
+
+    with pytest.raises(cmd_module.UserError, match="open 1a1u") as error:
+        cmd_module.fasthydromap(object())
+
+    assert "fasthydromap #1" in str(error.value)
+    assert "help fasthydromap" in str(error.value)
+
+
 def test_read_single_structure_scores(monkeypatch, tmp_path):
     cmd_module = _load_submodule(monkeypatch, "cmd")
     csv_path = tmp_path / "scores.csv"
@@ -188,6 +205,117 @@ def test_read_single_structure_scores_pc_quantity(monkeypatch, tmp_path):
 
     scores = cmd_module._read_single_structure_scores(csv_path, quantity="pc1")
     assert scores == {"A:1": 7.1, "_:2": -1.2}
+
+
+def test_save_protein_only_pdb_excludes_nucleic_acids_and_ligands(
+    monkeypatch, tmp_path
+):
+    cmd_module = _load_submodule(monkeypatch, "cmd")
+    deleted_atoms = []
+    saved_models = []
+
+    class FakeResidue:
+        PT_AMINO = 1
+
+        def __init__(self, polymer_type, atoms, name, number, chain_id="A"):
+            self.polymer_type = polymer_type
+            self.atoms = atoms
+            self.name = name
+            self.number = number
+            self.chain_id = chain_id
+            self.insertion_code = " "
+
+    class FakeAtoms(list):
+        def delete(self):
+            deleted_atoms.extend(self)
+
+    copy_model = types.SimpleNamespace(
+        residues=[
+            FakeResidue(
+                FakeResidue.PT_AMINO,
+                ["protein-N", "protein-CA"],
+                "ALA",
+                1,
+            ),
+            FakeResidue(2, ["dna-P", "dna-C1'"], "DC", 3, chain_id="P"),
+            FakeResidue(0, ["zinc"], "ZN", 1301),
+        ],
+        delete=lambda: setattr(copy_model, "was_deleted", True),
+        was_deleted=False,
+    )
+    structure = types.SimpleNamespace(
+        name="mixed complex",
+        residues=[
+            FakeResidue(FakeResidue.PT_AMINO, ["original-protein"], "ALA", 1),
+            FakeResidue(2, ["original-dna"], "DC", 3, chain_id="P"),
+            FakeResidue(0, ["original-zinc"], "ZN", 1301),
+        ],
+        copy=lambda name: copy_model,
+    )
+    warnings = []
+    session = types.SimpleNamespace(
+        logger=types.SimpleNamespace(warning=warnings.append)
+    )
+
+    atomic = types.ModuleType("chimerax.atomic")
+    atomic.Atoms = FakeAtoms
+    pdb = types.ModuleType("chimerax.pdb")
+    pdb.save_pdb = lambda session, path, models: saved_models.extend(models)
+    monkeypatch.setitem(sys.modules, "chimerax.atomic", atomic)
+    monkeypatch.setitem(sys.modules, "chimerax.pdb", pdb)
+
+    cmd_module._save_protein_only_pdb(session, structure, tmp_path / "model.pdb")
+
+    assert deleted_atoms == ["dna-P", "dna-C1'", "zinc"]
+    assert saved_models == [copy_model]
+    assert copy_model.was_deleted
+    assert len(warnings) == 1
+    assert "ignoring 2 non-protein residues" in warnings[0]
+    assert "P:3 DC" in warnings[0]
+    assert "A:1301 ZN" in warnings[0]
+
+
+def test_prediction_warning_describes_histidine_charge_limitations(monkeypatch):
+    cmd_module = _load_submodule(monkeypatch, "cmd")
+
+    def residue(name, number):
+        return types.SimpleNamespace(
+            name=name,
+            number=number,
+            chain_id="A",
+            insertion_code=" ",
+        )
+
+    warnings = []
+    session = types.SimpleNamespace(
+        logger=types.SimpleNamespace(warning=warnings.append)
+    )
+    cmd_module._warn_prediction_limitations(
+        session,
+        "model #1",
+        protein_residues=[residue("HIS", 5), residue("HID", 9), residue("ALA", 10)],
+        nonprotein_residues=[],
+    )
+
+    assert len(warnings) == 1
+    assert "assumes neutral histidine chemistry" in warnings[0]
+    assert "HID/HIE" in warnings[0]
+    assert "HIP/HSP" in warnings[0]
+    assert "A:5 HIS" in warnings[0]
+    assert "A:9 HID" in warnings[0]
+
+
+def test_save_protein_only_pdb_rejects_nonprotein_model(monkeypatch, tmp_path):
+    cmd_module = _load_submodule(monkeypatch, "cmd")
+
+    class FakeResidue:
+        PT_AMINO = 1
+        polymer_type = 2
+
+    structure = types.SimpleNamespace(residues=[FakeResidue()])
+
+    with pytest.raises(cmd_module.UserError, match="contains no protein residues"):
+        cmd_module._save_protein_only_pdb(object(), structure, tmp_path / "model.pdb")
 
 
 @pytest.mark.parametrize(
@@ -341,6 +469,8 @@ def test_install_command_uses_pypi_and_cli_torch(monkeypatch):
     install_module = _load_submodule(monkeypatch, "install")
     recorded = []
 
+    assert install_module.DEFAULT_PACKAGE_SPEC == "fasthydromap>=0.1.4,<0.2"
+
     monkeypatch.setattr(
         install_module,
         "log_subprocess_output",
@@ -390,3 +520,22 @@ def test_macos_app_translocation_detection(monkeypatch):
     assert not install_module._is_macos_app_translocation(
         "/private/var/folders/example/AppTranslocation/UUID/d/ChimeraX.app/Contents/bin/python3.11"
     )
+
+
+def test_install_success_logs_clickable_quick_start(monkeypatch):
+    install_module = _load_submodule(monkeypatch, "install")
+    calls = []
+    session = types.SimpleNamespace(
+        logger=types.SimpleNamespace(
+            info=lambda message, **kwargs: calls.append((message, kwargs))
+        )
+    )
+
+    install_module._log_ready_message(session)
+
+    message, kwargs = calls[0]
+    assert "FastHydroMap is ready" in message
+    assert 'cxcmd:open 1a1u' in message
+    assert 'cxcmd:fasthydromap #1' in message
+    assert 'cxcmd:help fasthydromap' in message
+    assert kwargs == {"is_html": True}

--- a/src/bundles/fasthydromap/tests/test_fasthydromap.py
+++ b/src/bundles/fasthydromap/tests/test_fasthydromap.py
@@ -121,8 +121,10 @@ def test_fasthydromap_command_prefers_env_override(monkeypatch):
     cmd_module = _load_submodule(monkeypatch, "cmd")
     monkeypatch.setenv("FASTHYDROMAP_EXE", "/custom/fasthydromap")
 
-    command = cmd_module._fasthydromap_command(object(), Path("model.pdb"), Path("out"), install_location=None)
-    assert command == ["/custom/fasthydromap", "predict", "model.pdb", "-o", "out"]
+    command = cmd_module._fasthydromap_command(
+        object(), Path("model.pdb"), Path("out"), quantity="pc1", install_location=None
+    )
+    assert command == ["/custom/fasthydromap", "predict", "model.pdb", "-o", "out", "--quantity", "pc1"]
 
 
 def test_fasthydromap_command_uses_managed_install(monkeypatch):
@@ -130,8 +132,10 @@ def test_fasthydromap_command_uses_managed_install(monkeypatch):
     monkeypatch.delenv("FASTHYDROMAP_EXE", raising=False)
     monkeypatch.setattr(cmd_module, "managed_fasthydromap_executable", lambda session, install_location=None: "/venv/bin/fasthydromap")
 
-    command = cmd_module._fasthydromap_command(object(), Path("model.pdb"), Path("out"), install_location="/venv")
-    assert command == ["/venv/bin/fasthydromap", "predict", "model.pdb", "-o", "out"]
+    command = cmd_module._fasthydromap_command(
+        object(), Path("model.pdb"), Path("out"), quantity="fdewet", install_location="/venv"
+    )
+    assert command == ["/venv/bin/fasthydromap", "predict", "model.pdb", "-o", "out", "--quantity", "fdewet"]
 
 
 def test_fasthydromap_command_requires_install(monkeypatch):
@@ -140,7 +144,9 @@ def test_fasthydromap_command_requires_install(monkeypatch):
     monkeypatch.setattr(cmd_module, "managed_fasthydromap_executable", lambda session, install_location=None: None)
 
     with pytest.raises(cmd_module.UserError, match="Run 'fasthydromap install' first"):
-        cmd_module._fasthydromap_command(object(), Path("model.pdb"), Path("out"), install_location=None)
+        cmd_module._fasthydromap_command(
+            object(), Path("model.pdb"), Path("out"), quantity="fdewet", install_location=None
+        )
 
 
 def test_read_single_structure_scores(monkeypatch, tmp_path):
@@ -159,6 +165,15 @@ def test_read_single_structure_scores_current_long_format(monkeypatch, tmp_path)
 
     scores = cmd_module._read_single_structure_scores(csv_path)
     assert scores == {"A:1": 4.1, "_:2": 5.2, "3A": 6.3}
+
+
+def test_read_single_structure_scores_pc_quantity(monkeypatch, tmp_path):
+    cmd_module = _load_submodule(monkeypatch, "cmd")
+    csv_path = tmp_path / "pc_scores.csv"
+    csv_path.write_text("residue,PC1\nA:1,7.1\n_:2,-1.2\n", encoding="utf-8")
+
+    scores = cmd_module._read_single_structure_scores(csv_path, quantity="pc1")
+    assert scores == {"A:1": 7.1, "_:2": -1.2}
 
 
 @pytest.mark.parametrize(
@@ -181,15 +196,114 @@ def test_color_structure_uses_fixed_palette_and_range(monkeypatch):
     commands = types.ModuleType("chimerax.core.commands")
     commands.run = lambda session, command: calls.append(command)
     monkeypatch.setitem(sys.modules, "chimerax.core.commands", commands)
+    colors = types.ModuleType("chimerax.core.colors")
+    colors.BuiltinColors = {"gray": "gray-color"}
+    monkeypatch.setitem(sys.modules, "chimerax.core.colors", colors)
+    std_color = types.ModuleType("chimerax.std_commands.color")
+    std_color.color_by_attr = lambda session, attr_name, **kwargs: calls.append(
+        ("color_by_attr", attr_name, kwargs)
+    )
+    monkeypatch.setitem(sys.modules, "chimerax.std_commands.color", std_color)
+    monkeypatch.setattr(cmd_module, "_resolve_palette", lambda palette: f"RESOLVED({palette})")
 
-    structure = types.SimpleNamespace(atomspec="#1")
-    cmd_module._color_structure(object(), structure, target="acs", show_atoms=False)
+    structure = types.SimpleNamespace(atomspec="#1", atoms="atoms-object")
+    cmd_module._color_structure(
+        object(),
+        structure,
+        target="acs",
+        show_atoms=False,
+        attr_name="fasthydromap_fdewet",
+        palette="^lipophilicity",
+        color_range=(4.0, 6.5),
+    )
 
     assert calls[-1] == (
-        "color byattribute r:fasthydromap_score #1 target acs "
-        "palette ^lipophilicity range 4,6.5 novalue gray"
+        "color_by_attr",
+        "r:fasthydromap_fdewet",
+        {
+            "atoms": "atoms-object",
+            "target": "acs",
+            "palette": "RESOLVED(^lipophilicity)",
+            "range": (4.0, 6.5),
+            "no_value_color": "gray-color",
+            "log_info": False,
+        },
     )
     assert "hide #1 bonds" not in calls
+
+
+def test_color_structure_uses_palette_and_range_overrides(monkeypatch):
+    cmd_module = _load_submodule(monkeypatch, "cmd")
+    calls = []
+
+    commands = types.ModuleType("chimerax.core.commands")
+    commands.run = lambda session, command: calls.append(command)
+    monkeypatch.setitem(sys.modules, "chimerax.core.commands", commands)
+    colors = types.ModuleType("chimerax.core.colors")
+    colors.BuiltinColors = {"gray": "gray-color"}
+    monkeypatch.setitem(sys.modules, "chimerax.core.colors", colors)
+    std_color = types.ModuleType("chimerax.std_commands.color")
+    std_color.color_by_attr = lambda session, attr_name, **kwargs: calls.append(
+        ("color_by_attr", attr_name, kwargs)
+    )
+    monkeypatch.setitem(sys.modules, "chimerax.std_commands.color", std_color)
+    palette_object = object()
+    monkeypatch.setattr(cmd_module, "_resolve_palette", lambda palette: f"RESOLVED({palette is palette_object})")
+
+    structure = types.SimpleNamespace(atomspec="#1", atoms="atoms-object")
+    cmd_module._color_structure(
+        object(),
+        structure,
+        target="acs",
+        show_atoms=True,
+        attr_name="fasthydromap_pc1",
+        palette=palette_object,
+        color_range=(3.5, 7),
+    )
+
+    assert calls[-1] == (
+        "color_by_attr",
+        "r:fasthydromap_pc1",
+        {
+            "atoms": "atoms-object",
+            "target": "acs",
+            "palette": "RESOLVED(True)",
+            "range": (3.5, 7),
+            "no_value_color": "gray-color",
+            "log_info": False,
+        },
+    )
+
+
+def test_pc_color_specs_use_requested_palettes_and_ranges(monkeypatch):
+    cmd_module = _load_submodule(monkeypatch, "cmd")
+    assert cmd_module.QUANTITY_SPECS["pc1"]["palette"] == "red-white-blue"
+    assert cmd_module.QUANTITY_SPECS["pc1"]["range"] == (-8.0, 8.0)
+    assert cmd_module.QUANTITY_SPECS["pc2"]["palette"] == "cyanmaroon"
+    assert cmd_module.QUANTITY_SPECS["pc2"]["range"] == (-2.0, 8.0)
+    assert cmd_module.QUANTITY_SPECS["pc3"]["palette"] == "^lipophilicity"
+    assert cmd_module.QUANTITY_SPECS["pc3"]["range"] == (-2.0, 2.0)
+
+
+def test_resolve_palette_supports_builtin_and_reversed(monkeypatch):
+    cmd_module = _load_submodule(monkeypatch, "cmd")
+
+    class FakeMap:
+        def __init__(self, name):
+            self.name = name
+
+        def reversed(self):
+            return f"reversed-{self.name}"
+
+    colors = types.ModuleType("chimerax.core.colors")
+    colors.BuiltinColormaps = {
+        "lipophilicity": FakeMap("lipophilicity"),
+        "red-white-blue": FakeMap("red-white-blue"),
+    }
+    monkeypatch.setitem(sys.modules, "chimerax.core.colors", colors)
+
+    assert cmd_module._resolve_palette("^lipophilicity") == "reversed-lipophilicity"
+    assert cmd_module._resolve_palette("red-white-blue").name == "red-white-blue"
 
 
 def test_find_structure_residue_handles_chainless_and_insertion_code(monkeypatch):

--- a/src/bundles/fasthydromap/tests/test_fasthydromap.py
+++ b/src/bundles/fasthydromap/tests/test_fasthydromap.py
@@ -1,12 +1,25 @@
 import importlib.util
 import sys
+import tomllib
 import types
 from pathlib import Path
 
 import pytest
 
 
-BUNDLE_SRC = Path(__file__).resolve().parents[1] / "src"
+BUNDLE_ROOT = Path(__file__).resolve().parents[1]
+BUNDLE_SRC = BUNDLE_ROOT / "src"
+
+
+def test_bundle_metadata_uses_license_expression_without_legacy_classifier():
+    with open(BUNDLE_ROOT / "pyproject.toml", "rb") as metadata_file:
+        metadata = tomllib.load(metadata_file)
+
+    assert metadata["project"]["license"] == "MIT"
+    assert not any(
+        classifier.startswith("License ::")
+        for classifier in metadata["tool"]["chimerax"]["classifiers"]
+    )
 
 
 def _stub_chimerax_modules(monkeypatch):

--- a/src/bundles/fasthydromap/tests/test_fasthydromap.py
+++ b/src/bundles/fasthydromap/tests/test_fasthydromap.py
@@ -1,0 +1,241 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+BUNDLE_SRC = Path(__file__).resolve().parents[1] / "src"
+
+
+def _stub_chimerax_modules(monkeypatch):
+    for name in list(sys.modules):
+        if name == "chimerax" or name.startswith("chimerax."):
+            monkeypatch.delitem(sys.modules, name, raising=False)
+
+    chimerax = types.ModuleType("chimerax")
+    chimerax.__path__ = []
+
+    core = types.ModuleType("chimerax.core")
+    core.__path__ = []
+
+    errors = types.ModuleType("chimerax.core.errors")
+
+    class UserError(Exception):
+        pass
+
+    errors.UserError = UserError
+
+    settings = types.ModuleType("chimerax.core.settings")
+
+    class Settings:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def save(self):
+            pass
+
+    settings.Settings = Settings
+
+    toolshed = types.ModuleType("chimerax.core.toolshed")
+
+    class BundleAPI:
+        pass
+
+    toolshed.BundleAPI = BundleAPI
+
+    monkeypatch.setitem(sys.modules, "chimerax", chimerax)
+    monkeypatch.setitem(sys.modules, "chimerax.core", core)
+    monkeypatch.setitem(sys.modules, "chimerax.core.errors", errors)
+    monkeypatch.setitem(sys.modules, "chimerax.core.settings", settings)
+    monkeypatch.setitem(sys.modules, "chimerax.core.toolshed", toolshed)
+    return UserError
+
+
+def _load_bundle_package(monkeypatch):
+    _stub_chimerax_modules(monkeypatch)
+    for name in ["fhm_bundle", "fhm_bundle.cmd", "fhm_bundle.install", "fhm_bundle.settings"]:
+        monkeypatch.delitem(sys.modules, name, raising=False)
+
+    spec = importlib.util.spec_from_file_location(
+        "fhm_bundle",
+        BUNDLE_SRC / "__init__.py",
+        submodule_search_locations=[str(BUNDLE_SRC)],
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["fhm_bundle"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_submodule(monkeypatch, submodule_name):
+    _load_bundle_package(monkeypatch)
+    fullname = f"fhm_bundle.{submodule_name}"
+    path = BUNDLE_SRC / f"{submodule_name}.py"
+    spec = importlib.util.spec_from_file_location(fullname, path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[fullname] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_register_command_dispatches(monkeypatch):
+    module = _load_bundle_package(monkeypatch)
+    calls = []
+
+    cmd_module = types.ModuleType("fhm_bundle.cmd")
+    cmd_module.register_fasthydromap_command = lambda logger: calls.append(("fasthydromap", logger))
+    install_module = types.ModuleType("fhm_bundle.install")
+    install_module.register_fasthydromap_install_command = lambda logger: calls.append(
+        ("fasthydromap install", logger)
+    )
+    monkeypatch.setitem(sys.modules, "fhm_bundle.cmd", cmd_module)
+    monkeypatch.setitem(sys.modules, "fhm_bundle.install", install_module)
+
+    module.bundle_api.register_command("fasthydromap", "log1")
+    module.bundle_api.register_command("fasthydromap install", "log2")
+
+    assert calls == [("fasthydromap", "log1"), ("fasthydromap install", "log2")]
+
+
+def test_settings_only_persist_install_location(monkeypatch):
+    settings_module = _load_submodule(monkeypatch, "settings")
+    assert settings_module._FastHydroMapSettings.EXPLICIT_SAVE == {
+        "fasthydromap_install_location": "",
+    }
+
+
+def test_managed_executable_uses_saved_install_location(monkeypatch):
+    install_module = _load_submodule(monkeypatch, "install")
+
+    saved = types.SimpleNamespace(fasthydromap_install_location="/tmp/fhm", save=lambda: None)
+    monkeypatch.setattr(install_module, "_fasthydromap_settings", lambda session: saved)
+    monkeypatch.setattr(install_module, "exists", lambda path: path == "/tmp/fhm/bin/fasthydromap")
+
+    exe = install_module.managed_fasthydromap_executable(object())
+    assert exe == "/tmp/fhm/bin/fasthydromap"
+
+
+def test_fasthydromap_command_prefers_env_override(monkeypatch):
+    cmd_module = _load_submodule(monkeypatch, "cmd")
+    monkeypatch.setenv("FASTHYDROMAP_EXE", "/custom/fasthydromap")
+
+    command = cmd_module._fasthydromap_command(object(), Path("model.pdb"), Path("out"), install_location=None)
+    assert command == ["/custom/fasthydromap", "predict", "model.pdb", "-o", "out"]
+
+
+def test_fasthydromap_command_uses_managed_install(monkeypatch):
+    cmd_module = _load_submodule(monkeypatch, "cmd")
+    monkeypatch.delenv("FASTHYDROMAP_EXE", raising=False)
+    monkeypatch.setattr(cmd_module, "managed_fasthydromap_executable", lambda session, install_location=None: "/venv/bin/fasthydromap")
+
+    command = cmd_module._fasthydromap_command(object(), Path("model.pdb"), Path("out"), install_location="/venv")
+    assert command == ["/venv/bin/fasthydromap", "predict", "model.pdb", "-o", "out"]
+
+
+def test_fasthydromap_command_requires_install(monkeypatch):
+    cmd_module = _load_submodule(monkeypatch, "cmd")
+    monkeypatch.delenv("FASTHYDROMAP_EXE", raising=False)
+    monkeypatch.setattr(cmd_module, "managed_fasthydromap_executable", lambda session, install_location=None: None)
+
+    with pytest.raises(cmd_module.UserError, match="Run 'fasthydromap install' first"):
+        cmd_module._fasthydromap_command(object(), Path("model.pdb"), Path("out"), install_location=None)
+
+
+def test_read_single_structure_scores(monkeypatch, tmp_path):
+    cmd_module = _load_submodule(monkeypatch, "cmd")
+    csv_path = tmp_path / "scores.csv"
+    csv_path.write_text("frame,A:1,_:2,3A\n0,4.1,5.2,6.3\n", encoding="utf-8")
+
+    scores = cmd_module._read_single_structure_scores(csv_path)
+    assert scores == {"A:1": 4.1, "_:2": 5.2, "3A": 6.3}
+
+
+def test_read_single_structure_scores_current_long_format(monkeypatch, tmp_path):
+    cmd_module = _load_submodule(monkeypatch, "cmd")
+    csv_path = tmp_path / "scores_long.csv"
+    csv_path.write_text("residue,Fdewet,Fdewet_intrinsic\nA:1,4.1,2.0\n_:2,5.2,2.5\n3A,6.3,3.1\n", encoding="utf-8")
+
+    scores = cmd_module._read_single_structure_scores(csv_path)
+    assert scores == {"A:1": 4.1, "_:2": 5.2, "3A": 6.3}
+
+
+@pytest.mark.parametrize(
+    "label,expected",
+    [
+        ("A:42", ("A", 42, "")),
+        ("_:7B", (" ", 7, "B")),
+        ("12A", (None, 12, "A")),
+    ],
+)
+def test_parse_residue_label(monkeypatch, label, expected):
+    cmd_module = _load_submodule(monkeypatch, "cmd")
+    assert cmd_module._parse_residue_label(label) == expected
+
+
+def test_color_structure_uses_fixed_palette_and_range(monkeypatch):
+    cmd_module = _load_submodule(monkeypatch, "cmd")
+    calls = []
+
+    commands = types.ModuleType("chimerax.core.commands")
+    commands.run = lambda session, command: calls.append(command)
+    monkeypatch.setitem(sys.modules, "chimerax.core.commands", commands)
+
+    structure = types.SimpleNamespace(atomspec="#1")
+    cmd_module._color_structure(object(), structure, target="acs", show_atoms=False)
+
+    assert calls[-1] == (
+        "color byattribute r:fasthydromap_score #1 target acs "
+        "palette ^lipophilicity range 4,6.5 novalue gray"
+    )
+    assert "hide #1 bonds" not in calls
+
+
+def test_find_structure_residue_handles_chainless_and_insertion_code(monkeypatch):
+    cmd_module = _load_submodule(monkeypatch, "cmd")
+
+    direct_residue = object()
+    chainless_residue = object()
+    find_calls = []
+
+    structure = types.SimpleNamespace(
+        find_residue=lambda chain_id, resid, insert=" ": find_calls.append((chain_id, resid, insert)) or direct_residue
+    )
+    no_chain_lookup = {"12A": chainless_residue}
+
+    assert cmd_module._find_structure_residue(structure, "A:7B", no_chain_lookup) is direct_residue
+    assert find_calls == [("A", 7, "B")]
+    assert cmd_module._find_structure_residue(structure, "12A", no_chain_lookup) is chainless_residue
+
+
+def test_install_command_uses_pypi_and_cli_torch(monkeypatch):
+    install_module = _load_submodule(monkeypatch, "install")
+    recorded = []
+
+    monkeypatch.setattr(
+        install_module,
+        "log_subprocess_output",
+        lambda session, command, finished_callback, wait=False: recorded.append(command),
+    )
+
+    session = types.SimpleNamespace(
+        logger=types.SimpleNamespace(info=lambda *a, **k: None),
+        ui=types.SimpleNamespace(is_gui=False),
+    )
+    installer = install_module.InstallFastHydroMap.__new__(install_module.InstallFastHydroMap)
+    installer._session = session
+    installer._directory = "/tmp/fhm"
+    installer._package_spec = "fasthydromap"
+    installer._torch_variant = "cpu"
+    installer._wait = True
+
+    installer._upgrade_packaging_tools()
+    installer._install_fasthydromap_package()
+    installer._install_torch()
+
+    assert recorded == [
+        ["/tmp/fhm/bin/python", "-m", "pip", "install", "--upgrade", "pip", "setuptools<81", "wheel"],
+        ["/tmp/fhm/bin/python", "-m", "pip", "install", "fasthydromap"],
+        ["/tmp/fhm/bin/fasthydromap", "install-torch", "--variant", "cpu"],
+    ]

--- a/src/bundles/fasthydromap/tests/test_fasthydromap.py
+++ b/src/bundles/fasthydromap/tests/test_fasthydromap.py
@@ -11,11 +11,12 @@ BUNDLE_ROOT = Path(__file__).resolve().parents[1]
 BUNDLE_SRC = BUNDLE_ROOT / "src"
 
 
-def test_bundle_metadata_uses_license_expression_without_legacy_classifier():
+def test_bundle_metadata_release_constraints():
     with open(BUNDLE_ROOT / "pyproject.toml", "rb") as metadata_file:
         metadata = tomllib.load(metadata_file)
 
     assert metadata["project"]["license"] == "MIT"
+    assert "ChimeraX-Core ~=1.12" in metadata["project"]["dependencies"]
     assert not any(
         classifier.startswith("License ::")
         for classifier in metadata["tool"]["chimerax"]["classifiers"]
@@ -372,3 +373,20 @@ def test_install_command_uses_pypi_and_cli_torch(monkeypatch):
         ],
         ["/tmp/fhm/bin/fasthydromap", "install-torch", "--variant", "cpu"],
     ]
+
+
+def test_macos_app_translocation_detection(monkeypatch):
+    install_module = _load_submodule(monkeypatch, "install")
+
+    monkeypatch.setattr(sys, "platform", "darwin")
+    assert install_module._is_macos_app_translocation(
+        "/private/var/folders/example/AppTranslocation/UUID/d/ChimeraX.app/Contents/bin/python3.11"
+    )
+    assert not install_module._is_macos_app_translocation(
+        "/Applications/ChimeraX-1.12.app/Contents/bin/python3.11"
+    )
+
+    monkeypatch.setattr(sys, "platform", "linux")
+    assert not install_module._is_macos_app_translocation(
+        "/private/var/folders/example/AppTranslocation/UUID/d/ChimeraX.app/Contents/bin/python3.11"
+    )


### PR DESCRIPTION
## Summary

This PR adds a new ChimeraX bundle for [FastHydroMap](https://github.com/samlobe/FastHydroMap) (a new hydrophobicity software; see [preprint](https://doi.org/10.64898/2026.06.07.730647)) with two commands:

- `fasthydromap install`
- `fasthydromap`

The bundle installs FastHydroMap into a ChimeraX-managed virtual environment from PyPI and runs predictions on atomic structures from within ChimeraX.

## Features

- managed install via `fasthydromap install`
- default CPU Torch install
- prediction quantities:
  - `fdewet`
  - `pc1`
  - `pc2`
  - `pc3`
- optional `palette` and `range` overrides for coloring
- no changes to the existing Hydrophobicity button or shortcuts

## Example commands

- `fasthydromap install`
- `fasthydromap #1`
- `fasthydromap #1 quantity pc1`
- `fasthydromap #1 palette ^lipophilicity range 3,7`

## Notes

This PR is intentionally command-only to keep the integration minimal and self-contained. If this FastHydroMap model becomes widely adopted, perhaps later the Hydrophobicity GUI button can be replaced with a call to this command, since the current MLP Hydrophobicity default is quite old (from 1998) and the hydrophobicity literature has advanced substantially since then. FastHydroMap is open-sourced and pip-installable.