### PR TITLE
fix(core): respect pre-set SSL_CERT_FILE instead of clobbering it

### DIFF
--- a/src/bundles/core/src/__main__.py
+++ b/src/bundles/core/src/__main__.py
@@ -579,9 +579,13 @@ def init(argv, event_loop=True):
     # Setup SSL CA certificates file
     # This used to be only necessary for darwin, but Windows
     # appears to need it as well.  So use it for all platforms.
+    # Use setdefault so that a SSL_CERT_FILE already set in the
+    # environment (e.g. pointing at an enterprise CA bundle behind a
+    # TLS-inspecting proxy) is respected instead of being overwritten
+    # by certifi's Mozilla bundle.
     import certifi
 
-    os.environ["SSL_CERT_FILE"] = certifi.where()
+    os.environ.setdefault("SSL_CERT_FILE", certifi.where())
 
     opts, args = parse_arguments(argv)
     if not opts.devel:


### PR DESCRIPTION
ChimeraX ships its own OpenSSL, which has no CA trust store, so at startup it points SSL_CERT_FILE at certifi's bundle. It did this with an unconditional assignment, which overwrote any SSL_CERT_FILE already present in the environment. In enterprise environments behind a TLS-inspecting proxy, users set SSL_CERT_FILE to a CA bundle that includes the internal root; that value was silently discarded, causing certificate verification failures on every HTTPS fetch (e.g. from the PDB).

Use os.environ.setdefault() so a pre-set SSL_CERT_FILE wins while the certifi default still applies for everyone else. Behavior is unchanged when the variable is unset.