### PR TITLE
Fix Tracker.__exit__ so the context manager works

### DIFF
--- a/src/bundles/core/src/data_events.py
+++ b/src/bundles/core/src/data_events.py
@@ -176,8 +176,9 @@ class Tracker:
 
     def __enter__(self):
         self.block()
+        return self
 
-    def __exit__(self):
+    def __exit__(self, exc_type, exc_value, traceback):
         self.release()
 
     def _activate(self, data_type):

--- a/src/bundles/core/tests/test_data_events.py
+++ b/src/bundles/core/tests/test_data_events.py
@@ -1,0 +1,33 @@
+import pytest
+
+
+def test_tracker_works_as_context_manager():
+    # Tracker.__exit__ took only self, so leaving a `with` block raised
+    # "TypeError: __exit__() takes 1 positional argument but 4 were given"
+    # and, because __exit__ never ran, left the tracker blocked.
+    from chimerax.core.data_events import Tracker
+
+    t = Tracker()
+    before = t._blocked
+    with t:
+        assert t._blocked == before + 1
+    assert t._blocked == before
+
+
+def test_tracker_releases_on_exception():
+    from chimerax.core.data_events import Tracker
+
+    t = Tracker()
+    before = t._blocked
+    with pytest.raises(ValueError):
+        with t:
+            raise ValueError("boom")
+    assert t._blocked == before
+
+
+def test_tracker_enter_returns_the_tracker():
+    from chimerax.core.data_events import Tracker
+
+    t = Tracker()
+    with t as entered:
+        assert entered is t


### PR DESCRIPTION
`Tracker` declares itself a context manager, but `__exit__` only takes `self`:

```python
def __enter__(self):
    self.block()

def __exit__(self):
    self.release()
```

Python calls `__exit__(exc_type, exc_value, traceback)`, so leaving any `with tracker:` block raises

```
TypeError: Tracker.__exit__() takes 1 positional argument but 4 were given
```

The worse half is what happens to the state. `__exit__` never runs, so `release()` never runs either, and `_blocked` stays incremented -- the trigger set is left blocked after the block it was supposed to guard has already ended. On a copy of the class:

```
TypeError: Tracker.__exit__() takes 1 positional argument but 4 were given
blocked after the failure: 1
```

`__enter__` also returns nothing, so `with tracker as t` binds `t` to `None`. Added `return self`.

Tests are in `src/bundles/core/tests/` per AGENTS.md -- normal exit, exit through an exception, and what `__enter__` hands back.

One thing worth knowing before you take this: `data_events` is not imported anywhere in `src/` right now, so nothing in the running app hits this and no bug report was ever going to arrive. The contract is broken for whoever picks up `Tracker` first.

Did not build or run the test suite