### PR TITLE
mcp_server: don't mistake a foreign HTTP server for ChimeraX

### DIFF
--- a/src/bundles/mcp_server/src/chimerax_mcp_bridge.py
+++ b/src/bundles/mcp_server/src/chimerax_mcp_bridge.py
@@ -64,8 +64,9 @@ Session Management Behavior:
 2. start_new_chimerax_session() ALWAYS forces a new instance (no auto-reuse)
 3. Commands without session_id use auto-discovery:
    - First checks default port
-   - Then scans common ports [8081, 8082, 8083, 7955, 9000]
-   - If none found, auto-starts on default port
+   - Then scans instances this bridge started, then _FALLBACK_PORTS
+   - If none found, auto-starts on default port (or, if another program
+     holds it, on the next free port)
 4. Auto-discovery NO LONGER changes the default port (use set_default_session() explicitly)
 5. check_chimerax_status() only checks, never starts ChimeraX
 """
@@ -94,6 +95,41 @@ _instances = {}  # port -> instance info
 _default_port = DEFAULT_CHIMERAX_PORT
 
 from mcp.server.fastmcp import FastMCP
+
+# Strings that must appear in rest_server's static/cmdline.html. Used to tell a
+# real ChimeraX REST server apart from any other HTTP server that happens to
+# hold the port. Both are long-standing fixtures of that file: the licence
+# banner is boilerplate in every ChimeraX source file, and the title has been
+# stable since the REST server was introduced.
+_CMDLINE_HTML_MARKERS = (
+    "=== UCSF ChimeraX Copyright ===",
+    "Chimera Web Command Line",
+)
+
+# Keys that rest_server's _run() always puts in a JSON-mode response. Their
+# absence means we are not talking to a ChimeraX REST server in JSON mode.
+_REST_ENVELOPE_KEYS = ("log messages", "error")
+
+
+class PortNotChimeraXError(Exception):
+    """An HTTP server answered where ChimeraX was expected, but is not one.
+
+    Raised when a port serves HTTP 200 without the ChimeraX JSON-mode response
+    envelope. Callers treat this like a refused connection -- the port is
+    unusable, so ChimeraX should be started elsewhere -- rather than believing
+    the empty response and reporting success.
+    """
+
+    def __init__(self, port: int, detail: str = ""):
+        self.port = port
+        message = (
+            f"Port {port} is serving HTTP but is not a ChimeraX REST server in "
+            f"JSON mode"
+        )
+        if detail:
+            message += f" ({detail})"
+        super().__init__(message + ".")
+
 
 def find_chimerax_executable():
     """Find ChimeraX executable, starting from bridge script location"""
@@ -157,8 +193,41 @@ def find_available_port(start_port: int = 8080) -> int:
             continue
     raise RuntimeError("No available ports found")
 
+# Ports to sweep when looking for an already-running ChimeraX, besides the
+# default one.
+_FALLBACK_PORTS = (8081, 8082, 8083, 7955, 9000)
+
+
+def _candidate_ports() -> list:
+    """Ports besides the default worth probing for a ChimeraX, best first.
+
+    Instances this bridge started come first. They matter because when the
+    default port is held by another program we start ChimeraX on whatever port
+    happens to be free, which need not be one of _FALLBACK_PORTS.
+
+    The default port is excluded: every caller checks it separately, first.
+    """
+    seen = {_default_port}
+    return [p for p in list(_instances) + list(_FALLBACK_PORTS)
+            if not (p in seen or seen.add(p))]
+
+
 async def is_chimerax_running(port: Optional[int] = None) -> bool:
-    """Check if ChimeraX REST server is running on specified port"""
+    """Check if a ChimeraX REST server is running on the specified port.
+
+    A bare "did something answer with 200?" check is not enough: port 8080 is
+    the most contended port in software (webpack, Flask, Jenkins, Tomcat,
+    Spring Boot, ...), and a stray server that answers 200 to everything would
+    otherwise be mistaken for ChimeraX -- suppressing auto-start and making
+    every subsequent command silently do nothing. So also require the body to
+    actually be ChimeraX's page.
+
+    We probe the static /cmdline.html rather than running a command via /run:
+    static files are served straight from the request handler thread, whereas
+    /run is dispatched onto the UI thread (session.ui.thread_safe). A busy
+    ChimeraX would fail a /run probe and get a redundant second instance
+    started underneath it.
+    """
     if port is None:
         port = _default_port
 
@@ -167,7 +236,10 @@ async def is_chimerax_running(port: Optional[int] = None) -> bool:
         # Use a simple GET request to a known static file
         url = f"http://{CHIMERAX_HOST}:{port}/cmdline.html"
         async with session.get(url, timeout=aiohttp.ClientTimeout(total=1)) as response:
-            return response.status == 200
+            if response.status != 200:
+                return False
+            body = await response.text()
+            return any(marker in body for marker in _CMDLINE_HTML_MARKERS)
     except:
         return False
 
@@ -236,7 +308,7 @@ async def check_existing_rest_server() -> tuple[bool, int]:
     """Check if ChimeraX already has a REST server running, returns (has_server, port)"""
 
     # Try to find any running ChimeraX instances first
-    for check_port in [_default_port] + [8081, 8082, 8083, 7955, 9000]:
+    for check_port in [_default_port] + _candidate_ports():
         if await is_chimerax_running(check_port):
             try:
                 # Found ChimeraX, check if it has REST server info
@@ -289,14 +361,19 @@ async def start_chimerax(port: Optional[int] = None, session_name: Optional[str]
         logger.info("ChimeraX is already running on port %d", port)
         return True, port
 
-    # If port is taken but not by ChimeraX, find a new one
-    if port != _default_port:
-        try:
-            import socket
-            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-                s.bind((CHIMERAX_HOST, port))
-        except OSError:
-            port = find_available_port(port)
+    # If the port is taken but not by ChimeraX, find a new one. This applies to
+    # the default port too: it used to be exempt, which meant a foreign server
+    # squatting on 8080 sent ChimeraX off to bind a port it could never get,
+    # and the launch just timed out.
+    try:
+        import socket
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.bind((CHIMERAX_HOST, port))
+    except OSError:
+        taken_port = port
+        port = find_available_port(port)
+        logger.info("Port %d is in use by another program; starting ChimeraX on "
+                    "port %d instead", taken_port, port)
 
     chimerax_path = find_chimerax_executable()
     if not chimerax_path:
@@ -468,9 +545,12 @@ async def find_best_chimerax_instance() -> int:
         logger.info("Using default ChimeraX instance on port %d", _default_port)
         return _default_port
 
-    # Quick scan for any running ChimeraX instances (common ports only)
+    # Quick scan for any running ChimeraX instances. Instances this bridge
+    # started come first: when the default port is held by another program we
+    # fall back to an arbitrary free port, which need not be in the fixed list
+    # below -- and forgetting it would start a redundant ChimeraX per command.
     # NOTE: We scan but DO NOT change _default_port anymore to avoid confusion
-    common_ports = [8081, 8082, 8083, 7955, 9000]  # Common alternatives
+    common_ports = _candidate_ports()
     for port in common_ports:
         if port == _default_port:
             continue  # Already checked
@@ -486,27 +566,45 @@ async def find_best_chimerax_instance() -> int:
     logger.info("No ChimeraX instances found, will try to start on port %d", _default_port)
     return _default_port
 
-async def _execute_command_request(session, url: str, command: str) -> dict:
+async def _execute_command_request(session, url: str, command: str, port: int) -> dict:
     """Helper to execute a ChimeraX command and parse the response.
-    
+
     Args:
         session: aiohttp ClientSession
         url: Full URL to the ChimeraX /run endpoint
         command: ChimeraX command to execute
-    
+        port: Port `url` points at; used to report port conflicts
+
     Returns:
         dict with 'return_values', 'json_values', and 'logs' keys
-    
+
     Raises:
+        PortNotChimeraXError if the responder is not a JSON-mode ChimeraX
         Exception if request fails or ChimeraX returns an error (with helpful hints)
     """
     params = {'command': command}
-    
+
     async with session.get(url, params=params) as response:
         if response.status == 200:
-            # Parse JSON response
-            data = await response.json()
-            
+            # Parse JSON response. A non-JSON 200 means we are either talking to
+            # something that is not ChimeraX at all, or to a REST server started
+            # without `json true` (which replies text/plain).
+            try:
+                data = await response.json()
+            except aiohttp.ContentTypeError as e:
+                raise PortNotChimeraXError(
+                    port, f"replied {response.content_type}, not JSON") from e
+
+            # rest_server's _run() always emits the full envelope in JSON mode,
+            # so anything else -- notably a server that answers `{}` to every
+            # request -- is not ChimeraX. Without this check an empty reply
+            # looks like a command that simply produced no output, and every
+            # command reports success while doing nothing at all.
+            if not isinstance(data, dict) or not all(
+                    key in data for key in _REST_ENVELOPE_KEYS):
+                raise PortNotChimeraXError(
+                    port, "response lacked the ChimeraX JSON envelope")
+
             if logger.isEnabledFor(logging.DEBUG):
                 import json as _json
                 logger.debug("Response for %r (url=%s): %s",
@@ -554,9 +652,21 @@ async def run_chimerax_command(command: str, port: Optional[int] = None) -> dict
 
     try:
         # Use GET with query parameters (JSON mode enabled at startup)
-        return await _execute_command_request(session, url, command)
+        return await _execute_command_request(session, url, command, port)
 
-    except aiohttp.ClientConnectorError:
+    except (aiohttp.ClientConnectorError, PortNotChimeraXError) as exc:
+        # Nothing usable at `port`. Either nobody answered (ClientConnectorError)
+        # or somebody did but is not a JSON-mode ChimeraX. Distinguish the one
+        # case where starting a second ChimeraX would be wrong: a real ChimeraX
+        # whose REST server was started without `json true`.
+        if isinstance(exc, PortNotChimeraXError) and await is_chimerax_running(port):
+            raise Exception(
+                f"ChimeraX is running on port {port}, but its REST server is not "
+                f"in JSON mode, so the MCP bridge cannot read command results. "
+                f"Run `mcp start` in that ChimeraX to reconfigure it (or "
+                f"`remotecontrol rest start port {port} json true log true`)."
+            ) from exc
+
         # Try to start ChimeraX if it's not running
         success, actual_port = await start_chimerax(port)
         if success:
@@ -564,9 +674,13 @@ async def run_chimerax_command(command: str, port: Optional[int] = None) -> dict
             if actual_port != port:
                 base_url = get_chimerax_url(actual_port)
                 url = f"{base_url}/run"
-            
+
             # Retry the command after starting ChimeraX
-            return await _execute_command_request(session, url, command)
+            return await _execute_command_request(session, url, command, actual_port)
+        elif isinstance(exc, PortNotChimeraXError):
+            raise Exception(
+                f"{exc} ChimeraX could not be started on another port either."
+            ) from exc
         else:
             raise Exception(f"Cannot connect to ChimeraX at {base_url} and failed to start ChimeraX automatically.")
     except Exception as e:

--- a/src/bundles/mcp_server/tests/test_bridge_port_conflict.py
+++ b/src/bundles/mcp_server/tests/test_bridge_port_conflict.py
@@ -1,0 +1,254 @@
+"""Tests for the MCP bridge's handling of a contended REST port.
+
+Port 8080 is the bridge's default and one of the most contended ports in
+software. If an unrelated HTTP server holds it, the bridge must notice rather
+than mistake it for ChimeraX -- otherwise every command "succeeds" while doing
+nothing, which is exactly what a stray mock server answering `{}` to every
+request once produced.
+
+These are pure unit tests: they stand up small HTTP stubs on ephemeral ports
+and never need a ChimeraX session.
+"""
+
+import asyncio
+import json
+import socket
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import pytest
+
+pytest.importorskip("aiohttp")
+pytest.importorskip("mcp")
+
+from chimerax.mcpserver import chimerax_mcp_bridge as bridge  # noqa: E402
+
+
+# The real page the bridge fingerprints ChimeraX with; only the markers matter.
+CMDLINE_HTML = b"""<html lang="en"><!--
+=== UCSF ChimeraX Copyright ===
+--><head><meta charset="utf-8">
+<title>Chimera Web Command Line</title>
+</head><body></body></html>
+"""
+
+CHIMERAX_ENVELOPE = {
+    "json values": [None],
+    "python values": ["opened 1 model"],
+    "log messages": {"info": ["1 model opened"]},
+    "error": None,
+}
+
+
+def _make_handler(run_body, run_content_type, serve_cmdline_html):
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            if self.path.startswith("/run"):
+                body, ctype = run_body, run_content_type
+            elif serve_cmdline_html:
+                body, ctype = CMDLINE_HTML, "text/html"
+            else:
+                # Models a server that answers everything identically -- the
+                # behaviour that fooled the old status-code-only probe.
+                body, ctype = run_body, run_content_type
+            self.send_response(200)
+            self.send_header("Content-Type", ctype)
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, *args):
+            pass
+
+    return Handler
+
+
+def _serve(handler_cls):
+    """Run handler_cls on an ephemeral port; return (port, shutdown_callable)."""
+    httpd = HTTPServer(("localhost", 0), handler_cls)
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+
+    def shutdown():
+        httpd.shutdown()
+        httpd.server_close()
+        thread.join(timeout=5)
+
+    return httpd.server_address[1], shutdown
+
+
+@pytest.fixture
+def imposter():
+    """A server that answers 200 + `{}` to every path, ChimeraX or not."""
+    port, shutdown = _serve(_make_handler(b"{}", "application/json", False))
+    yield port
+    shutdown()
+
+
+@pytest.fixture
+def chimerax_json_mode():
+    """A stand-in for a real ChimeraX REST server started with `json true`."""
+    body = json.dumps(CHIMERAX_ENVELOPE).encode()
+    port, shutdown = _serve(_make_handler(body, "application/json", True))
+    yield port
+    shutdown()
+
+
+@pytest.fixture
+def chimerax_no_json_mode():
+    """Real ChimeraX, but `remotecontrol rest start` without `json true`."""
+    port, shutdown = _serve(
+        _make_handler(b"1 model opened", "text/plain", True))
+    yield port
+    shutdown()
+
+
+@pytest.fixture(autouse=True)
+def clean_bridge_state():
+    """Keep the bridge's module-level instance registry out of other tests."""
+    saved = dict(bridge._instances)
+    bridge._instances.clear()
+    yield
+    bridge._instances.clear()
+    bridge._instances.update(saved)
+
+
+@pytest.fixture(autouse=True)
+def close_bridge_session():
+    yield
+    session = bridge._session
+    if session is not None and not session.closed:
+        asyncio.get_event_loop_policy().new_event_loop().run_until_complete(
+            session.close())
+    bridge._session = None
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+# --- the liveness probe must verify identity, not just liveness -------------
+
+def test_probe_rejects_imposter(imposter):
+    assert run(bridge.is_chimerax_running(imposter)) is False
+
+
+def test_probe_accepts_real_chimerax(chimerax_json_mode):
+    assert run(bridge.is_chimerax_running(chimerax_json_mode)) is True
+
+
+def test_probe_accepts_chimerax_without_json_mode(chimerax_no_json_mode):
+    # cmdline.html is served regardless of the REST server's json setting, so
+    # this is still a ChimeraX -- the distinction is drawn later, on /run.
+    assert run(bridge.is_chimerax_running(chimerax_no_json_mode)) is True
+
+
+def test_probe_rejects_dead_port():
+    with socket.socket() as s:
+        s.bind(("localhost", 0))
+        dead_port = s.getsockname()[1]
+    assert run(bridge.is_chimerax_running(dead_port)) is False
+
+
+# --- an imposter must never be mistaken for a successful command ------------
+
+def test_imposter_does_not_yield_a_fake_success(imposter, monkeypatch):
+    """The regression: `{}` used to format as "Command completed successfully"."""
+    monkeypatch.setattr(
+        bridge, "start_chimerax",
+        lambda *a, **kw: _async_return((False, imposter)))
+
+    with pytest.raises(Exception) as excinfo:
+        run(bridge.run_chimerax_command("open 1gcn", imposter))
+
+    assert "Command completed successfully" not in str(excinfo.value)
+    assert str(imposter) in str(excinfo.value)
+
+
+def test_imposter_triggers_autostart_elsewhere(imposter, chimerax_json_mode,
+                                               monkeypatch):
+    """Squatted port -> start ChimeraX on another port -> retry -> real result."""
+    started = {}
+
+    async def fake_start(port=None, session_name=None, force_new=False):
+        started["asked_for"] = port
+        return True, chimerax_json_mode
+
+    monkeypatch.setattr(bridge, "start_chimerax", fake_start)
+
+    result = run(bridge.run_chimerax_command("open 1gcn", imposter))
+
+    assert started["asked_for"] == imposter
+    assert result["return_values"] == ["opened 1 model"]
+    assert result["logs"] == {"info": ["1 model opened"]}
+
+
+def test_real_chimerax_without_json_mode_is_not_duplicated(
+        chimerax_no_json_mode, monkeypatch):
+    """Don't start a second ChimeraX just because JSON mode is off."""
+    def refuse(*args, **kwargs):
+        raise AssertionError("start_chimerax must not be called here")
+
+    monkeypatch.setattr(bridge, "start_chimerax", refuse)
+
+    with pytest.raises(Exception) as excinfo:
+        run(bridge.run_chimerax_command("open 1gcn", chimerax_no_json_mode))
+
+    assert "mcp start" in str(excinfo.value)
+
+
+def test_healthy_chimerax_still_works(chimerax_json_mode):
+    result = run(bridge.run_chimerax_command("open 1gcn", chimerax_json_mode))
+    assert result["return_values"] == ["opened 1 model"]
+
+
+# --- the default port must not be exempt from the availability check --------
+
+def test_start_chimerax_moves_off_a_squatted_default_port(imposter, monkeypatch):
+    """The guard `if port != _default_port` used to skip this check entirely."""
+    launched = {}
+
+    def fake_daemon(port):
+        launched["port"] = port
+        return True
+
+    monkeypatch.setattr(bridge, "_default_port", imposter)
+    monkeypatch.setattr(bridge, "start_chimerax_daemon", fake_daemon)
+    monkeypatch.setattr(bridge, "find_chimerax_executable", lambda: "/bin/true")
+    # Skip the "is an existing REST server already up?" sweep and the 30 s wait.
+    monkeypatch.setattr(bridge, "check_existing_rest_server",
+                        lambda: _async_return((False, imposter)))
+    monkeypatch.setattr(bridge, "is_chimerax_running",
+                        lambda port=None: _async_return(port == launched.get("port")))
+
+    success, port = run(bridge.start_chimerax(imposter))
+
+    assert success
+    assert port != imposter, "should have moved off the squatted port"
+    assert launched["port"] == port
+
+
+# --- discovery must not forget an instance started on an unusual port -------
+
+def test_candidate_ports_includes_started_instances(monkeypatch):
+    monkeypatch.setattr(bridge, "_default_port", 8080)
+    bridge._instances[9137] = {"status": "running"}
+
+    ports = bridge._candidate_ports()
+
+    assert ports[0] == 9137, "bridge-started instances should be probed first"
+    assert 8080 not in ports, "the default port is checked separately"
+    assert len(ports) == len(set(ports)), "no duplicate probes"
+
+
+def test_candidate_ports_drops_default_from_fallbacks(monkeypatch):
+    monkeypatch.setattr(bridge, "_default_port", 8082)
+    assert 8082 not in bridge._candidate_ports()
+
+
+async def _async_return_impl(value):
+    return value
+
+
+def _async_return(value):
+    return _async_return_impl(value)


### PR DESCRIPTION
## The problem

If any program other than ChimeraX is listening on the MCP bridge's port, the
bridge reports that every command succeeded while nothing happens at all.

I hit this with a stale mock server left running on port 8080 that answered
`200` with `{}` to every request. An agent asked to open a structure and a map,
style the volume and set the view. All four commands came back
`"Command completed successfully"`. ChimeraX had never been launched — and was
never even looked for.

Three fail-open steps compound:

1. `is_chimerax_running()` GETs `/cmdline.html` and returns `response.status
   == 200`. Any 200 means "ChimeraX is running here."
2. `_execute_command_request()` gets a 200 with parseable JSON, finds no
   `error` key, and returns empty return values, JSON values and logs.
3. `format_chimerax_response()` has nothing to report and falls through to the
   literal string `"Command completed successfully"`.

Auto-start never fires, because it hangs off `aiohttp.ClientConnectorError` and
a squatter *answers* rather than refusing the connection.

Port 8080 is `DEFAULT_CHIMERAX_PORT` and also the default for webpack, Flask,
Jenkins, Tomcat, Spring Boot and countless dev stubs, so this is easy to hit by
accident. The failure is silent, which makes it worse than a crash: an agent
confidently reports work it did not do.

## The fix

- **`is_chimerax_running()`** additionally requires `/cmdline.html` to actually
  be ChimeraX's page. I kept probing the static file rather than switching to
  `/run`: static files are served straight from the request handler thread,
  whereas `/run` is dispatched onto the UI thread via `session.ui.thread_safe`,
  so a busy ChimeraX would fail a `/run` probe and get a redundant second
  instance started underneath it.

- **`_execute_command_request()`** rejects a 200 that lacks `rest_server`'s
  JSON-mode envelope, raising a new `PortNotChimeraXError`. `_run()` always
  emits `json values`, `python values`, `log messages` and `error` in JSON
  mode, so this is a reliable invariant.

- **`run_chimerax_command()`** handles that exception like a refused
  connection, so ChimeraX gets started elsewhere. One case is carved out: if
  the port really is ChimeraX whose REST server was started without
  `json true`, it reports how to fix it (`mcp start`) instead of spawning a
  duplicate instance.

- **`start_chimerax()`** no longer exempts the default port from its
  availability check. That exemption was the reason a squatted 8080 could not
  recover: ChimeraX was sent off to bind a port it could never get, and the
  launch simply timed out. Now the bind test runs for every port and a taken
  one moves to the next free port.

- **`find_best_chimerax_instance()` / `check_existing_rest_server()`** consult
  instances this bridge started before sweeping the fixed fallback list. Once
  we can land on an arbitrary free port, the fixed list alone can no longer
  find our own instance, and each subsequent command would start another
  ChimeraX. The fallback list is now a single `_FALLBACK_PORTS` constant rather
  than being spelled out in three places.

Net effect: a squatted default port becomes invisible. ChimeraX starts on the
next free port, the command is retried there, and the user sees a normal
result.

`format_chimerax_response()`'s `"Command completed successfully"` string is
deliberately unchanged. Once the envelope is known to be genuine, an empty
result is legitimate — `view` and friends really do log nothing.

## Tests

New `src/bundles/mcp_server/tests/test_bridge_port_conflict.py`, 11 tests using
small stub HTTP servers on ephemeral ports; no ChimeraX session required.
Covers an imposter answering `{}` to everything, a real JSON-mode ChimeraX, a
real ChimeraX with JSON mode off, a dead port, the default-port availability
check, and candidate-port ordering.

Seven of the eleven fail against the current code; the other four are
no-regression controls that pass either way. The central one fails with
`DID NOT RAISE` — that is the bug.

## Verification

Beyond the unit tests, checked against real ChimeraX instances on macOS:

- Squatted default port: probe rejects the imposter, the bind test moves to the
  next port, ChimeraX launches there, the command is retried, and a real PDB
  opens as model #1 with genuine chain-info logs.
- Real ChimeraX started with `remotecontrol rest start port N` (no `json
  true`): produces the "run `mcp start`" error, with `start_chimerax`
  instrumented to assert it is never called.
- Healthy default port: still discovered and driven exactly as before.

## Note

The module docstring advertises `CHIMERAX_REST_HOST` and `CHIMERAX_REST_PORT`
environment variables that the code never reads. That is a genuine doc/code
mismatch and a useful escape hatch on a busy machine, but it is independent of
this bug, so I have left it for a separate PR to keep this diff focused.