### PR TITLE
mcp_server: let CHIMERAX_REST_PORT pin the bridge to one ChimeraX

### DIFF
--- a/src/bundles/mcp_server/src/chimerax_mcp_bridge.py
+++ b/src/bundles/mcp_server/src/chimerax_mcp_bridge.py
@@ -64,8 +64,9 @@ Session Management Behavior:
 2. start_new_chimerax_session() ALWAYS forces a new instance (no auto-reuse)
 3. Commands without session_id use auto-discovery:
    - First checks default port
-   - Then scans common ports [8081, 8082, 8083, 7955, 9000]
-   - If none found, auto-starts on default port
+   - Then scans instances this bridge started, then _FALLBACK_PORTS
+   - If none found, auto-starts on default port (or, if another program
+     holds it, on the next free port)
 4. Auto-discovery NO LONGER changes the default port (use set_default_session() explicitly)
 5. check_chimerax_status() only checks, never starts ChimeraX
 """
@@ -94,6 +95,41 @@ _instances = {}  # port -> instance info
 _default_port = DEFAULT_CHIMERAX_PORT
 
 from mcp.server.fastmcp import FastMCP
+
+# Strings that must appear in rest_server's static/cmdline.html. Used to tell a
+# real ChimeraX REST server apart from any other HTTP server that happens to
+# hold the port. Both are long-standing fixtures of that file: the licence
+# banner is boilerplate in every ChimeraX source file, and the title has been
+# stable since the REST server was introduced.
+_CMDLINE_HTML_MARKERS = (
+    "=== UCSF ChimeraX Copyright ===",
+    "Chimera Web Command Line",
+)
+
+# Keys that rest_server's _run() always puts in a JSON-mode response. Their
+# absence means we are not talking to a ChimeraX REST server in JSON mode.
+_REST_ENVELOPE_KEYS = ("log messages", "error")
+
+
+class PortNotChimeraXError(Exception):
+    """An HTTP server answered where ChimeraX was expected, but is not one.
+
+    Raised when a port serves HTTP 200 without the ChimeraX JSON-mode response
+    envelope. Callers treat this like a refused connection -- the port is
+    unusable, so ChimeraX should be started elsewhere -- rather than believing
+    the empty response and reporting success.
+    """
+
+    def __init__(self, port: int, detail: str = ""):
+        self.port = port
+        message = (
+            f"Port {port} is serving HTTP but is not a ChimeraX REST server in "
+            f"JSON mode"
+        )
+        if detail:
+            message += f" ({detail})"
+        super().__init__(message + ".")
+
 
 def find_chimerax_executable():
     """Find ChimeraX executable, starting from bridge script location"""
@@ -157,8 +193,41 @@ def find_available_port(start_port: int = 8080) -> int:
             continue
     raise RuntimeError("No available ports found")
 
+# Ports to sweep when looking for an already-running ChimeraX, besides the
+# default one.
+_FALLBACK_PORTS = (8081, 8082, 8083, 7955, 9000)
+
+
+def _candidate_ports() -> list:
+    """Ports besides the default worth probing for a ChimeraX, best first.
+
+    Instances this bridge started come first. They matter because when the
+    default port is held by another program we start ChimeraX on whatever port
+    happens to be free, which need not be one of _FALLBACK_PORTS.
+
+    The default port is excluded: every caller checks it separately, first.
+    """
+    seen = {_default_port}
+    return [p for p in list(_instances) + list(_FALLBACK_PORTS)
+            if not (p in seen or seen.add(p))]
+
+
 async def is_chimerax_running(port: Optional[int] = None) -> bool:
-    """Check if ChimeraX REST server is running on specified port"""
+    """Check if a ChimeraX REST server is running on the specified port.
+
+    A bare "did something answer with 200?" check is not enough: port 8080 is
+    the most contended port in software (webpack, Flask, Jenkins, Tomcat,
+    Spring Boot, ...), and a stray server that answers 200 to everything would
+    otherwise be mistaken for ChimeraX -- suppressing auto-start and making
+    every subsequent command silently do nothing. So also require the body to
+    actually be ChimeraX's page.
+
+    We probe the static /cmdline.html rather than running a command via /run:
+    static files are served straight from the request handler thread, whereas
+    /run is dispatched onto the UI thread (session.ui.thread_safe). A busy
+    ChimeraX would fail a /run probe and get a redundant second instance
+    started underneath it.
+    """
     if port is None:
         port = _default_port
 
@@ -167,7 +236,10 @@ async def is_chimerax_running(port: Optional[int] = None) -> bool:
         # Use a simple GET request to a known static file
         url = f"http://{CHIMERAX_HOST}:{port}/cmdline.html"
         async with session.get(url, timeout=aiohttp.ClientTimeout(total=1)) as response:
-            return response.status == 200
+            if response.status != 200:
+                return False
+            body = await response.text()
+            return any(marker in body for marker in _CMDLINE_HTML_MARKERS)
     except:
         return False
 
@@ -236,7 +308,7 @@ async def check_existing_rest_server() -> tuple[bool, int]:
     """Check if ChimeraX already has a REST server running, returns (has_server, port)"""
 
     # Try to find any running ChimeraX instances first
-    for check_port in [_default_port] + [8081, 8082, 8083, 7955, 9000]:
+    for check_port in [_default_port] + _candidate_ports():
         if await is_chimerax_running(check_port):
             try:
                 # Found ChimeraX, check if it has REST server info
@@ -289,14 +361,19 @@ async def start_chimerax(port: Optional[int] = None, session_name: Optional[str]
         logger.info("ChimeraX is already running on port %d", port)
         return True, port
 
-    # If port is taken but not by ChimeraX, find a new one
-    if port != _default_port:
-        try:
-            import socket
-            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-                s.bind((CHIMERAX_HOST, port))
-        except OSError:
-            port = find_available_port(port)
+    # If the port is taken but not by ChimeraX, find a new one. This applies to
+    # the default port too: it used to be exempt, which meant a foreign server
+    # squatting on 8080 sent ChimeraX off to bind a port it could never get,
+    # and the launch just timed out.
+    try:
+        import socket
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.bind((CHIMERAX_HOST, port))
+    except OSError:
+        taken_port = port
+        port = find_available_port(port)
+        logger.info("Port %d is in use by another program; starting ChimeraX on "
+                    "port %d instead", taken_port, port)
 
     chimerax_path = find_chimerax_executable()
     if not chimerax_path:
@@ -468,9 +545,12 @@ async def find_best_chimerax_instance() -> int:
         logger.info("Using default ChimeraX instance on port %d", _default_port)
         return _default_port
 
-    # Quick scan for any running ChimeraX instances (common ports only)
+    # Quick scan for any running ChimeraX instances. Instances this bridge
+    # started come first: when the default port is held by another program we
+    # fall back to an arbitrary free port, which need not be in the fixed list
+    # below -- and forgetting it would start a redundant ChimeraX per command.
     # NOTE: We scan but DO NOT change _default_port anymore to avoid confusion
-    common_ports = [8081, 8082, 8083, 7955, 9000]  # Common alternatives
+    common_ports = _candidate_ports()
     for port in common_ports:
         if port == _default_port:
             continue  # Already checked
@@ -486,27 +566,45 @@ async def find_best_chimerax_instance() -> int:
     logger.info("No ChimeraX instances found, will try to start on port %d", _default_port)
     return _default_port
 
-async def _execute_command_request(session, url: str, command: str) -> dict:
+async def _execute_command_request(session, url: str, command: str, port: int) -> dict:
     """Helper to execute a ChimeraX command and parse the response.
-    
+
     Args:
         session: aiohttp ClientSession
         url: Full URL to the ChimeraX /run endpoint
         command: ChimeraX command to execute
-    
+        port: Port `url` points at; used to report port conflicts
+
     Returns:
         dict with 'return_values', 'json_values', and 'logs' keys
-    
+
     Raises:
+        PortNotChimeraXError if the responder is not a JSON-mode ChimeraX
         Exception if request fails or ChimeraX returns an error (with helpful hints)
     """
     params = {'command': command}
-    
+
     async with session.get(url, params=params) as response:
         if response.status == 200:
-            # Parse JSON response
-            data = await response.json()
-            
+            # Parse JSON response. A non-JSON 200 means we are either talking to
+            # something that is not ChimeraX at all, or to a REST server started
+            # without `json true` (which replies text/plain).
+            try:
+                data = await response.json()
+            except aiohttp.ContentTypeError as e:
+                raise PortNotChimeraXError(
+                    port, f"replied {response.content_type}, not JSON") from e
+
+            # rest_server's _run() always emits the full envelope in JSON mode,
+            # so anything else -- notably a server that answers `{}` to every
+            # request -- is not ChimeraX. Without this check an empty reply
+            # looks like a command that simply produced no output, and every
+            # command reports success while doing nothing at all.
+            if not isinstance(data, dict) or not all(
+                    key in data for key in _REST_ENVELOPE_KEYS):
+                raise PortNotChimeraXError(
+                    port, "response lacked the ChimeraX JSON envelope")
+
             if logger.isEnabledFor(logging.DEBUG):
                 import json as _json
                 logger.debug("Response for %r (url=%s): %s",
@@ -554,9 +652,21 @@ async def run_chimerax_command(command: str, port: Optional[int] = None) -> dict
 
     try:
         # Use GET with query parameters (JSON mode enabled at startup)
-        return await _execute_command_request(session, url, command)
+        return await _execute_command_request(session, url, command, port)
 
-    except aiohttp.ClientConnectorError:
+    except (aiohttp.ClientConnectorError, PortNotChimeraXError) as exc:
+        # Nothing usable at `port`. Either nobody answered (ClientConnectorError)
+        # or somebody did but is not a JSON-mode ChimeraX. Distinguish the one
+        # case where starting a second ChimeraX would be wrong: a real ChimeraX
+        # whose REST server was started without `json true`.
+        if isinstance(exc, PortNotChimeraXError) and await is_chimerax_running(port):
+            raise Exception(
+                f"ChimeraX is running on port {port}, but its REST server is not "
+                f"in JSON mode, so the MCP bridge cannot read command results. "
+                f"Run `mcp start` in that ChimeraX to reconfigure it (or "
+                f"`remotecontrol rest start port {port} json true log true`)."
+            ) from exc
+
         # Try to start ChimeraX if it's not running
         success, actual_port = await start_chimerax(port)
         if success:
@@ -564,9 +674,13 @@ async def run_chimerax_command(command: str, port: Optional[int] = None) -> dict
             if actual_port != port:
                 base_url = get_chimerax_url(actual_port)
                 url = f"{base_url}/run"
-            
+
             # Retry the command after starting ChimeraX
-            return await _execute_command_request(session, url, command)
+            return await _execute_command_request(session, url, command, actual_port)
+        elif isinstance(exc, PortNotChimeraXError):
+            raise Exception(
+                f"{exc} ChimeraX could not be started on another port either."
+            ) from exc
         else:
             raise Exception(f"Cannot connect to ChimeraX at {base_url} and failed to start ChimeraX automatically.")
     except Exception as e:

--- a/src/bundles/mcp_server/src/chimerax_mcp_bridge.py
+++ b/src/bundles/mcp_server/src/chimerax_mcp_bridge.py
@@ -59,14 +59,39 @@ Multi-Instance Usage:
 - Use list_chimerax_instances() to see all running instances
 - Use set_default_session() to change default target
 
+Environment:
+- CHIMERAX_REST_HOST  host the REST server is reachable on (default localhost)
+- CHIMERAX_REST_PORT  pin the bridge to one ChimeraX (see below); unset by
+                      default, in which case the port is 8080 and discovery
+                      behaves as it always has
+
+Pinned mode (CHIMERAX_REST_PORT):
+Setting the port says "I already know which ChimeraX you should talk to", so
+the bridge takes it literally and does two further things:
+- It does not scan for other instances. Discovery exists to guess a port; when
+  one was supplied there is nothing to guess, and guessing is harmful -- a
+  momentarily unresponsive ChimeraX would otherwise send commands to somebody
+  else's instance on a fallback port.
+- It does not auto-start ChimeraX. A caller that pinned a port either started
+  that ChimeraX itself or knows who did. Launching a second one behind its
+  back is never the repair it wants, and on a display-less machine the launch
+  cannot succeed anyway.
+An explicit session_id argument still overrides the pin for a single call;
+only the *default* target is fixed.
+
+This is what makes the bridge usable for headless and parallel work: a caller
+can start N ChimeraX REST servers, hand each bridge its own port, and know
+that no bridge will wander onto a sibling's instance.
+
 Session Management Behavior:
-1. Default port starts at 8080 (configurable)
+1. Default port starts at 8080, or CHIMERAX_REST_PORT when that is set
 2. start_new_chimerax_session() ALWAYS forces a new instance (no auto-reuse)
 3. Commands without session_id use auto-discovery:
    - First checks default port
    - Then scans instances this bridge started, then _FALLBACK_PORTS
    - If none found, auto-starts on default port (or, if another program
      holds it, on the next free port)
+   - Skipped entirely when CHIMERAX_REST_PORT pins the port
 4. Auto-discovery NO LONGER changes the default port (use set_default_session() explicitly)
 5. check_chimerax_status() only checks, never starts ChimeraX
 """
@@ -86,9 +111,38 @@ from typing import Optional
 
 logger = logging.getLogger("chimerax-bridge")
 
-# ChimeraX connection settings
-CHIMERAX_HOST = 'localhost'
-DEFAULT_CHIMERAX_PORT = 8080
+# ChimeraX connection settings. Both are read from the environment, which is
+# how the documented client configurations above have always advertised them.
+
+
+def _env_port(name: str) -> Optional[int]:
+    """Read a TCP port from environment variable `name`, or None if unusable.
+
+    A bad value is reported and ignored rather than raised: this runs at import
+    time in a stdio MCP server, where an exception is an opaque startup failure
+    for the user, and falling back to the normal default is a safe outcome.
+    """
+    raw = os.environ.get(name)
+    if not raw:
+        return None
+    try:
+        port = int(raw)
+    except ValueError:
+        logger.warning("Ignoring %s=%r: not an integer", name, raw)
+        return None
+    if not 1 <= port <= 65535:
+        logger.warning("Ignoring %s=%r: not a valid TCP port", name, raw)
+        return None
+    return port
+
+
+CHIMERAX_HOST = os.environ.get('CHIMERAX_REST_HOST') or 'localhost'
+
+# When set, the bridge talks to exactly this ChimeraX: no discovery scan and no
+# auto-start. See "Pinned mode" in the module docstring for why both follow.
+PINNED_PORT = _env_port('CHIMERAX_REST_PORT')
+
+DEFAULT_CHIMERAX_PORT = PINNED_PORT if PINNED_PORT is not None else 8080
 
 # Global state for managing multiple ChimeraX instances
 _instances = {}  # port -> instance info
@@ -206,7 +260,12 @@ def _candidate_ports() -> list:
     happens to be free, which need not be one of _FALLBACK_PORTS.
 
     The default port is excluded: every caller checks it separately, first.
+
+    Empty when the port is pinned: the caller named the instance, so there is
+    nothing to guess and a guess could only land on somebody else's ChimeraX.
     """
+    if PINNED_PORT is not None:
+        return []
     seen = {_default_port}
     return [p for p in list(_instances) + list(_FALLBACK_PORTS)
             if not (p in seen or seen.add(p))]
@@ -346,6 +405,19 @@ async def start_chimerax(port: Optional[int] = None, session_name: Optional[str]
     """
     if port is None:
         port = _default_port
+
+    # Pinned: never launch ChimeraX. The caller either started the pinned
+    # instance or knows who did, so a second one is not the repair it wants --
+    # and where pinning is most useful (headless nodes, parallel harnesses) the
+    # launch could not succeed anyway. Reporting failure lets callers surface
+    # "the ChimeraX you pinned is not answering", which is the actionable fact.
+    if PINNED_PORT is not None:
+        if await is_chimerax_running(PINNED_PORT):
+            return True, PINNED_PORT
+        logger.error(
+            "No ChimeraX REST server is answering on pinned port %d "
+            "(CHIMERAX_REST_PORT); not starting one", PINNED_PORT)
+        return False, PINNED_PORT
 
     # First check if there's already a ChimeraX with REST server running (unless forcing new)
     # NOTE: We only do this auto-discovery if port is None and force_new is False
@@ -539,6 +611,12 @@ async def find_best_chimerax_instance() -> int:
     Use set_default_session() explicitly if you want to change the default port.
     """
     global _default_port
+
+    # Pinned: the caller supplied the port, so return it without probing. Not
+    # even a liveness check -- a pinned ChimeraX that is briefly busy must not
+    # cause us to fall through to a different instance.
+    if PINNED_PORT is not None:
+        return PINNED_PORT
 
     # First check if default port is running
     if await is_chimerax_running(_default_port):
@@ -1972,6 +2050,12 @@ async def start_new_chimerax_session(session_name: Optional[str] = None, port: O
         session_name: Optional name for the session (defaults to session_<port>)
         port: Specific port to use (defaults to finding available port)
     """
+    if PINNED_PORT is not None:
+        # Say so here rather than letting start_chimerax() refuse further down,
+        # which would report a failure against a port the caller never chose.
+        return (f"This bridge is pinned to the ChimeraX on port {PINNED_PORT} "
+                f"by CHIMERAX_REST_PORT and does not start new instances.")
+
     if port is None:
         # Find an available port, starting from the default
         port = find_available_port(_default_port)
@@ -2036,6 +2120,11 @@ async def set_default_session(session_id: int) -> str:
         session_id: ChimeraX session port to use as default
     """
     global _default_port
+
+    if PINNED_PORT is not None:
+        return (f"The default session is pinned to port {PINNED_PORT} by "
+                f"CHIMERAX_REST_PORT and cannot be changed. Pass session_id "
+                f"explicitly to target another instance for a single command.")
 
     if not await is_chimerax_running(session_id):
         return f"No ChimeraX instance running on port {session_id}"

--- a/src/bundles/mcp_server/tests/test_bridge_pinned_port.py
+++ b/src/bundles/mcp_server/tests/test_bridge_pinned_port.py
@@ -1,0 +1,223 @@
+"""Tests for pinning the MCP bridge to one ChimeraX with CHIMERAX_REST_PORT.
+
+The bridge's documented client configurations have always shown a
+CHIMERAX_REST_HOST / CHIMERAX_REST_PORT env block, but nothing read it: the
+host and port were module constants. Without it there is no way to tell one
+bridge "talk to *that* ChimeraX", which is what headless and parallel callers
+need -- they start their own REST servers and must not have the bridge wander
+onto a sibling's instance or launch a GUI behind their back.
+
+Pinning therefore implies three things, and each is tested here: the port is
+used, discovery is skipped, and auto-start is refused.
+
+The settings are read at import time, so these tests reload the module under a
+patched environment. That is also the shape of the real contract -- an MCP
+stdio server is spawned per session with its env already set.
+"""
+
+import asyncio
+import importlib
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import pytest
+
+pytest.importorskip("aiohttp")
+pytest.importorskip("mcp")
+
+from chimerax.mcpserver import chimerax_mcp_bridge as bridge  # noqa: E402
+
+
+CMDLINE_HTML = b"""<html lang="en"><!--
+=== UCSF ChimeraX Copyright ===
+--><head><meta charset="utf-8">
+<title>Chimera Web Command Line</title>
+</head><body></body></html>
+"""
+
+CHIMERAX_ENVELOPE = {
+    "json values": [None],
+    "python values": ["opened 1 model"],
+    "log messages": {"info": ["1 model opened"]},
+    "error": None,
+}
+
+
+def _serve():
+    """A stand-in ChimeraX REST server on an ephemeral port."""
+    body = json.dumps(CHIMERAX_ENVELOPE).encode()
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            if self.path.startswith("/run"):
+                payload, ctype = body, "application/json"
+            else:
+                payload, ctype = CMDLINE_HTML, "text/html"
+            self.send_response(200)
+            self.send_header("Content-Type", ctype)
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+
+        def log_message(self, *args):
+            pass
+
+    httpd = HTTPServer(("localhost", 0), Handler)
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+
+    def shutdown():
+        httpd.shutdown()
+        httpd.server_close()
+        thread.join(timeout=5)
+
+    return httpd.server_address[1], shutdown
+
+
+@pytest.fixture
+def chimerax():
+    port, shutdown = _serve()
+    yield port
+    shutdown()
+
+
+@pytest.fixture
+def pinned(monkeypatch):
+    """Reload the bridge with CHIMERAX_REST_PORT set to a given port."""
+    def _pin(port):
+        monkeypatch.setenv("CHIMERAX_REST_PORT", str(port))
+        return importlib.reload(bridge)
+    yield _pin
+    # Restore the unpinned module so later tests see the normal defaults.
+    monkeypatch.delenv("CHIMERAX_REST_PORT", raising=False)
+    importlib.reload(bridge)
+
+
+@pytest.fixture(autouse=True)
+def close_bridge_session():
+    """Drop the cached aiohttp session; it is bound to a now-closed loop."""
+    yield
+    # reload() mutates the module in place, so this is the live object either way.
+    session = bridge._session
+    if session is not None and not session.closed:
+        asyncio.get_event_loop_policy().new_event_loop().run_until_complete(
+            session.close())
+    bridge._session = None
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+# --- the pin is read at all -------------------------------------------------
+
+def test_pin_sets_the_default_port(pinned):
+    mod = pinned(9123)
+    assert mod.PINNED_PORT == 9123
+    assert mod.DEFAULT_CHIMERAX_PORT == 9123
+    assert mod._default_port == 9123
+
+
+def test_host_is_configurable(monkeypatch):
+    monkeypatch.setenv("CHIMERAX_REST_HOST", "127.0.0.1")
+    mod = importlib.reload(bridge)
+    try:
+        assert mod.CHIMERAX_HOST == "127.0.0.1"
+    finally:
+        monkeypatch.delenv("CHIMERAX_REST_HOST", raising=False)
+        importlib.reload(bridge)
+
+
+def test_unset_env_keeps_the_historical_defaults():
+    assert bridge.PINNED_PORT is None
+    assert bridge.DEFAULT_CHIMERAX_PORT == 8080
+    assert bridge.CHIMERAX_HOST == "localhost"
+
+
+@pytest.mark.parametrize("value", ["", "http://localhost:8080", "eighty-eighty",
+                                   "0", "-1", "65536"])
+def test_unusable_values_fall_back_rather_than_crash(monkeypatch, value):
+    # An exception here would be an opaque startup failure in a stdio server.
+    monkeypatch.setenv("CHIMERAX_REST_PORT", value)
+    mod = importlib.reload(bridge)
+    try:
+        assert mod.PINNED_PORT is None
+        assert mod.DEFAULT_CHIMERAX_PORT == 8080
+    finally:
+        monkeypatch.delenv("CHIMERAX_REST_PORT", raising=False)
+        importlib.reload(bridge)
+
+
+# --- pinning skips discovery ------------------------------------------------
+
+def test_pinned_lookup_skips_the_scan(pinned):
+    mod = pinned(9123)
+    # No server is listening on 9123. Unpinned, this would scan the fallback
+    # list; pinned, it must return the pinned port regardless -- a busy or
+    # briefly-down ChimeraX must not divert commands to another instance.
+    assert run(mod.find_best_chimerax_instance()) == 9123
+
+
+def test_pinned_candidate_list_is_empty(pinned):
+    mod = pinned(9123)
+    mod._instances[9200] = {"status": "running"}
+    try:
+        assert mod._candidate_ports() == []
+    finally:
+        mod._instances.clear()
+
+
+def test_unpinned_lookup_still_scans():
+    # Guard the default path: the fallback list is still consulted.
+    assert bridge._candidate_ports()
+
+
+# --- pinning refuses to auto-start ------------------------------------------
+
+def test_pinned_start_refuses_when_nothing_answers(pinned):
+    mod = pinned(9123)
+    ok, port = run(mod.start_chimerax())
+    assert ok is False
+    assert port == 9123
+
+
+def test_pinned_start_never_launches_a_process(pinned, monkeypatch):
+    mod = pinned(9123)
+    monkeypatch.setattr(mod, "find_chimerax_executable",
+                        lambda: pytest.fail("must not look for an executable"))
+    monkeypatch.setattr(mod, "start_chimerax_daemon",
+                        lambda port: pytest.fail("must not launch ChimeraX"))
+    assert run(mod.start_chimerax())[0] is False
+
+
+def test_pinned_start_succeeds_when_the_pinned_server_answers(pinned, chimerax):
+    mod = pinned(chimerax)
+    assert run(mod.start_chimerax()) == (True, chimerax)
+
+
+# --- the pin holds against the tools ----------------------------------------
+
+def test_set_default_session_is_refused_while_pinned(pinned, chimerax):
+    mod = pinned(9123)
+    message = run(mod.set_default_session(chimerax))
+    assert "pinned" in message.lower()
+    assert mod._default_port == 9123
+
+
+def test_start_new_session_is_refused_while_pinned(pinned, monkeypatch):
+    mod = pinned(9123)
+    monkeypatch.setattr(mod, "find_chimerax_executable",
+                        lambda: pytest.fail("must not look for an executable"))
+    message = run(mod.start_new_chimerax_session())
+    assert "pinned" in message.lower()
+    assert "9123" in message
+
+
+def test_set_default_session_still_works_unpinned(chimerax):
+    saved = bridge._default_port
+    try:
+        run(bridge.set_default_session(chimerax))
+        assert bridge._default_port == chimerax
+    finally:
+        bridge._default_port = saved

--- a/src/bundles/mcp_server/tests/test_bridge_port_conflict.py
+++ b/src/bundles/mcp_server/tests/test_bridge_port_conflict.py
@@ -1,0 +1,254 @@
+"""Tests for the MCP bridge's handling of a contended REST port.
+
+Port 8080 is the bridge's default and one of the most contended ports in
+software. If an unrelated HTTP server holds it, the bridge must notice rather
+than mistake it for ChimeraX -- otherwise every command "succeeds" while doing
+nothing, which is exactly what a stray mock server answering `{}` to every
+request once produced.
+
+These are pure unit tests: they stand up small HTTP stubs on ephemeral ports
+and never need a ChimeraX session.
+"""
+
+import asyncio
+import json
+import socket
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import pytest
+
+pytest.importorskip("aiohttp")
+pytest.importorskip("mcp")
+
+from chimerax.mcpserver import chimerax_mcp_bridge as bridge  # noqa: E402
+
+
+# The real page the bridge fingerprints ChimeraX with; only the markers matter.
+CMDLINE_HTML = b"""<html lang="en"><!--
+=== UCSF ChimeraX Copyright ===
+--><head><meta charset="utf-8">
+<title>Chimera Web Command Line</title>
+</head><body></body></html>
+"""
+
+CHIMERAX_ENVELOPE = {
+    "json values": [None],
+    "python values": ["opened 1 model"],
+    "log messages": {"info": ["1 model opened"]},
+    "error": None,
+}
+
+
+def _make_handler(run_body, run_content_type, serve_cmdline_html):
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            if self.path.startswith("/run"):
+                body, ctype = run_body, run_content_type
+            elif serve_cmdline_html:
+                body, ctype = CMDLINE_HTML, "text/html"
+            else:
+                # Models a server that answers everything identically -- the
+                # behaviour that fooled the old status-code-only probe.
+                body, ctype = run_body, run_content_type
+            self.send_response(200)
+            self.send_header("Content-Type", ctype)
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, *args):
+            pass
+
+    return Handler
+
+
+def _serve(handler_cls):
+    """Run handler_cls on an ephemeral port; return (port, shutdown_callable)."""
+    httpd = HTTPServer(("localhost", 0), handler_cls)
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+
+    def shutdown():
+        httpd.shutdown()
+        httpd.server_close()
+        thread.join(timeout=5)
+
+    return httpd.server_address[1], shutdown
+
+
+@pytest.fixture
+def imposter():
+    """A server that answers 200 + `{}` to every path, ChimeraX or not."""
+    port, shutdown = _serve(_make_handler(b"{}", "application/json", False))
+    yield port
+    shutdown()
+
+
+@pytest.fixture
+def chimerax_json_mode():
+    """A stand-in for a real ChimeraX REST server started with `json true`."""
+    body = json.dumps(CHIMERAX_ENVELOPE).encode()
+    port, shutdown = _serve(_make_handler(body, "application/json", True))
+    yield port
+    shutdown()
+
+
+@pytest.fixture
+def chimerax_no_json_mode():
+    """Real ChimeraX, but `remotecontrol rest start` without `json true`."""
+    port, shutdown = _serve(
+        _make_handler(b"1 model opened", "text/plain", True))
+    yield port
+    shutdown()
+
+
+@pytest.fixture(autouse=True)
+def clean_bridge_state():
+    """Keep the bridge's module-level instance registry out of other tests."""
+    saved = dict(bridge._instances)
+    bridge._instances.clear()
+    yield
+    bridge._instances.clear()
+    bridge._instances.update(saved)
+
+
+@pytest.fixture(autouse=True)
+def close_bridge_session():
+    yield
+    session = bridge._session
+    if session is not None and not session.closed:
+        asyncio.get_event_loop_policy().new_event_loop().run_until_complete(
+            session.close())
+    bridge._session = None
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+# --- the liveness probe must verify identity, not just liveness -------------
+
+def test_probe_rejects_imposter(imposter):
+    assert run(bridge.is_chimerax_running(imposter)) is False
+
+
+def test_probe_accepts_real_chimerax(chimerax_json_mode):
+    assert run(bridge.is_chimerax_running(chimerax_json_mode)) is True
+
+
+def test_probe_accepts_chimerax_without_json_mode(chimerax_no_json_mode):
+    # cmdline.html is served regardless of the REST server's json setting, so
+    # this is still a ChimeraX -- the distinction is drawn later, on /run.
+    assert run(bridge.is_chimerax_running(chimerax_no_json_mode)) is True
+
+
+def test_probe_rejects_dead_port():
+    with socket.socket() as s:
+        s.bind(("localhost", 0))
+        dead_port = s.getsockname()[1]
+    assert run(bridge.is_chimerax_running(dead_port)) is False
+
+
+# --- an imposter must never be mistaken for a successful command ------------
+
+def test_imposter_does_not_yield_a_fake_success(imposter, monkeypatch):
+    """The regression: `{}` used to format as "Command completed successfully"."""
+    monkeypatch.setattr(
+        bridge, "start_chimerax",
+        lambda *a, **kw: _async_return((False, imposter)))
+
+    with pytest.raises(Exception) as excinfo:
+        run(bridge.run_chimerax_command("open 1gcn", imposter))
+
+    assert "Command completed successfully" not in str(excinfo.value)
+    assert str(imposter) in str(excinfo.value)
+
+
+def test_imposter_triggers_autostart_elsewhere(imposter, chimerax_json_mode,
+                                               monkeypatch):
+    """Squatted port -> start ChimeraX on another port -> retry -> real result."""
+    started = {}
+
+    async def fake_start(port=None, session_name=None, force_new=False):
+        started["asked_for"] = port
+        return True, chimerax_json_mode
+
+    monkeypatch.setattr(bridge, "start_chimerax", fake_start)
+
+    result = run(bridge.run_chimerax_command("open 1gcn", imposter))
+
+    assert started["asked_for"] == imposter
+    assert result["return_values"] == ["opened 1 model"]
+    assert result["logs"] == {"info": ["1 model opened"]}
+
+
+def test_real_chimerax_without_json_mode_is_not_duplicated(
+        chimerax_no_json_mode, monkeypatch):
+    """Don't start a second ChimeraX just because JSON mode is off."""
+    def refuse(*args, **kwargs):
+        raise AssertionError("start_chimerax must not be called here")
+
+    monkeypatch.setattr(bridge, "start_chimerax", refuse)
+
+    with pytest.raises(Exception) as excinfo:
+        run(bridge.run_chimerax_command("open 1gcn", chimerax_no_json_mode))
+
+    assert "mcp start" in str(excinfo.value)
+
+
+def test_healthy_chimerax_still_works(chimerax_json_mode):
+    result = run(bridge.run_chimerax_command("open 1gcn", chimerax_json_mode))
+    assert result["return_values"] == ["opened 1 model"]
+
+
+# --- the default port must not be exempt from the availability check --------
+
+def test_start_chimerax_moves_off_a_squatted_default_port(imposter, monkeypatch):
+    """The guard `if port != _default_port` used to skip this check entirely."""
+    launched = {}
+
+    def fake_daemon(port):
+        launched["port"] = port
+        return True
+
+    monkeypatch.setattr(bridge, "_default_port", imposter)
+    monkeypatch.setattr(bridge, "start_chimerax_daemon", fake_daemon)
+    monkeypatch.setattr(bridge, "find_chimerax_executable", lambda: "/bin/true")
+    # Skip the "is an existing REST server already up?" sweep and the 30 s wait.
+    monkeypatch.setattr(bridge, "check_existing_rest_server",
+                        lambda: _async_return((False, imposter)))
+    monkeypatch.setattr(bridge, "is_chimerax_running",
+                        lambda port=None: _async_return(port == launched.get("port")))
+
+    success, port = run(bridge.start_chimerax(imposter))
+
+    assert success
+    assert port != imposter, "should have moved off the squatted port"
+    assert launched["port"] == port
+
+
+# --- discovery must not forget an instance started on an unusual port -------
+
+def test_candidate_ports_includes_started_instances(monkeypatch):
+    monkeypatch.setattr(bridge, "_default_port", 8080)
+    bridge._instances[9137] = {"status": "running"}
+
+    ports = bridge._candidate_ports()
+
+    assert ports[0] == 9137, "bridge-started instances should be probed first"
+    assert 8080 not in ports, "the default port is checked separately"
+    assert len(ports) == len(set(ports)), "no duplicate probes"
+
+
+def test_candidate_ports_drops_default_from_fallbacks(monkeypatch):
+    monkeypatch.setattr(bridge, "_default_port", 8082)
+    assert 8082 not in bridge._candidate_ports()
+
+
+async def _async_return_impl(value):
+    return value
+
+
+def _async_return(value):
+    return _async_return_impl(value)


### PR DESCRIPTION
## The problem

The bridge's own documented client configuration has always shown this:

```json
"env": {
  "CHIMERAX_REST_HOST": "localhost",
  "CHIMERAX_REST_PORT": "8080"
}
```

Nothing reads it. `CHIMERAX_HOST` and `DEFAULT_CHIMERAX_PORT` are module
constants, and there is no `os.environ` lookup anywhere in the file. So the
documented way to point a bridge at a particular ChimeraX has never worked, and
there is no other way to do it.

That leaves no way to run more than one agent/ChimeraX pair reliably, which is
odd for a bridge whose header advertises "M-to-N architecture: multiple agents
controlling multiple ChimeraX instances."

Concretely, if I start three ChimeraX REST servers and point three bridges at
them, each bridge can drift onto the wrong one:

- `find_best_chimerax_instance()` sweeps `_FALLBACK_PORTS` whenever the default
  port does not answer. A ChimeraX that is merely busy — mid-render, or running
  a long command on the UI thread — fails the probe, and its agent silently
  gets a *sibling's* instance. The commands succeed, against the wrong models.
- Auto-start compounds it. `start_chimerax()` fires on a connection error and
  launches a whole new ChimeraX. On a display-less machine that cannot work at
  all: `start_chimerax_daemon()` runs the launcher without `--nogui`, so the
  attempt just times out. (Filed separately — this PR does not change it.)

Neither is a bug in isolation; both are the right default when the bridge has
to *guess* which ChimeraX to use. The gap is that there is no way to tell it
not to guess.

## The fix

Read both variables, and treat a supplied port as a **pin** rather than a hint.
`CHIMERAX_REST_PORT` says "I already know which ChimeraX you should talk to",
and two things follow from taking that literally:

- **No discovery scan.** Discovery exists to guess a port. When one was given
  there is nothing to guess, and guessing can only reach the wrong instance.
  `find_best_chimerax_instance()` returns the pinned port without probing —
  deliberately not even a liveness check, since a brief non-answer is exactly
  when the old code would divert to a sibling.
- **No auto-start.** A caller that pinned a port either started that ChimeraX
  or knows who did; a second one is not the repair it wants. `start_chimerax()`
  returns `(False, port)`, which callers already treat like a refused
  connection, so the failure surfaces as "the ChimeraX you pinned is not
  answering" — the actionable fact.

`start_new_chimerax_session()` and `set_default_session()` say so plainly
rather than failing obscurely further down. An explicit `session_id` argument
still overrides the pin for a single command; only the *default* target is
fixed, so multi-instance use from one agent is unaffected.

`CHIMERAX_REST_HOST` is now read too, as documented.

## Compatibility

Unset, nothing changes: port 8080, discovery and auto-start exactly as before.
There are tests asserting that specifically, since it is the path essentially
every existing user is on.

An unusable value (`""`, `"eighty-eighty"`, `0`, `-1`, `65536`) is logged and
ignored rather than raised. This runs at import time in a stdio MCP server,
where an exception is an opaque startup failure for the user and the normal
default is a safe outcome.

## Tests

`src/bundles/mcp_server/tests/test_bridge_pinned_port.py` — 18 unit tests, no
ChimeraX session needed; the live cases stand up a small HTTP stub on an
ephemeral port, following `test_bridge_port_conflict.py`. They cover: the pin is
read; the host is read; unset keeps the historical defaults; bad values fall
back; discovery is skipped; auto-start is refused and never looks for an
executable; a pinned server that *is* answering reports success; the two tools
refuse; and the unpinned paths still scan and still allow `set_default_session`.

The settings are module-level, so the tests reload the module under a patched
environment — which is also the real contract, since an MCP stdio server is
spawned per session with its env already set.

29 pass across the bundle (18 new + 11 from #255).