### PR TITLE
Allow non-localhost cross-origin requests

### DIFF
--- a/docs/user/commands/remotecontrol.html
+++ b/docs/user/commands/remotecontrol.html
@@ -42,7 +42,7 @@ Either of the following methods of communication can be used:
 [&nbsp;<b>ssl</b>&nbsp;&nbsp;true&nbsp;|&nbsp;<b>false</b>&nbsp;]
 [&nbsp;<b>json</b>&nbsp;&nbsp;true&nbsp;|&nbsp;<b>false</b>&nbsp;]
 [&nbsp;<b>log</b>&nbsp;&nbsp;true&nbsp;|&nbsp;<b>false</b>&nbsp;]
-[&nbsp;<b>cors</b>&nbsp;&nbsp;true&nbsp;|&nbsp;<b>false</b>&nbsp;]
+[&nbsp;<b>cors</b>&nbsp;&nbsp;true&nbsp;|&nbsp;allow-list&nbsp;|&nbsp;<b>false</b>&nbsp;]
 <br>
 <a href="usageconventions.html"><b>Usage</b></a>:
 <b>remotecontrol rest stop</b>
@@ -93,10 +93,10 @@ The <b>cors</b> option enables
 With <b>cors true</b>, the server will respond with appropriate
 <code>Access-Control-Allow-Origin</code> headers for requests originating from
 <code>http://localhost:*</code>, <code>http://127.0.0.1:*</code>, or their HTTPS equivalents.
-This is useful for browser-based applications (such as interactive tutorials or web-based tools)
+With <b>cors allow-list</b>, the server will allow requests from a comma-separated list of origins.
+Allowing cross-origin requests is useful for browser-based applications (such as interactive tutorials or web-based tools)
 that need to communicate with ChimeraX via JavaScript <code>fetch()</code> from a different port.
 The default is <b>cors false</b>, which blocks cross-origin requests.
-Note that CORS is only enabled for localhost origins as a security measure.
 </p><p>
 If sending large data, use POST with "multipart/form-data" in the header.
 </p><p>

--- a/src/bundles/rest_server/src/cmd.py
+++ b/src/bundles/rest_server/src/cmd.py
@@ -55,9 +55,11 @@ def start_server(session, log=None, port=None, ssl=None, json=False, cors=False)
          LEVEL_DESCRIPTS, and values that are lists of messages logged at that level during command
          execution.
 
-    If 'cors' is True, then CORS (Cross-Origin Resource Sharing) headers will be sent to allow
-    requests from localhost origins (http://localhost:* and http://127.0.0.1:*). This is useful
-    for browser-based applications that need to communicate with ChimeraX from a different port.
+    If 'cors' is a list of request origins, then CORS (Cross-Origin Resource Sharing) headers will be
+    sent to allow requests from those origins. If 'cors' is True, localhost origins
+    (http://localhost:* and http://127.0.0.1:*) are allowed. If 'cors' is False, then CORS headers
+    will deny all origins. This is useful for browser-based applications that need to communicate with
+    ChimeraX from a different port.
     """
 
     global _server
@@ -77,7 +79,7 @@ def start_server(session, log=None, port=None, ssl=None, json=False, cors=False)
             _server.start(port, ssl, json)
 
 
-from chimerax.core.commands import CmdDesc, IntArg, BoolArg
+from chimerax.core.commands import CmdDesc, IntArg, BoolArg, StringArg, Or
 
 start_desc = CmdDesc(
     keyword=[
@@ -85,7 +87,7 @@ start_desc = CmdDesc(
         ("ssl", BoolArg),
         ("json", BoolArg),
         ("log", BoolArg),
-        ("cors", BoolArg),
+        ("cors", Or(BoolArg, StringArg)),
     ],
     synopsis="Start REST server",
 )

--- a/src/bundles/rest_server/src/server.py
+++ b/src/bundles/rest_server/src/server.py
@@ -25,6 +25,7 @@
 from http.server import BaseHTTPRequestHandler
 from chimerax.core.tasks import Task
 from chimerax.core.logger import PlainTextLog, StringPlainTextLog
+from urllib.parse import urlparse
 
 
 class RESTServer(Task):
@@ -35,7 +36,27 @@ class RESTServer(Task):
 
         self.httpd = None
         self.log = kw.pop("log", False)
-        self.cors = kw.pop("cors", False)
+        cors = kw.pop("cors", False)
+        self.allowed_origins = set()
+        if not cors:
+            self.cors = False
+        elif isinstance(cors, str):
+            self.cors = True
+            for url in cors.split(","):
+                parsed = urlparse(url)
+                if parsed.scheme not in ["http", "https"] or not parsed.netloc:
+                    continue
+                self.allowed_origins.add((parsed.scheme, parsed.netloc))
+        else:
+            self.cors = True
+            self.allowed_origins = set([
+                ("http", "localhost"),
+                ("https", "localhost"),
+                ("http", "127.0.0.1"),
+                ("https", "127.0.0.1"),
+                ("http", "::1"),
+                ("https", "::1"),
+            ])
         self.run_count = 0
         self.run_lock = threading.Lock()
         super().__init__(*args, **kw)
@@ -64,6 +85,23 @@ class RESTServer(Task):
     @property
     def server_address(self):
         return self.httpd.server_address
+
+    def _is_allowed_origin(self, origin):
+        """Check if an origin should be allowed by CORS.
+
+        Returns True if the origin is in the allowlist, False otherwise.
+        """
+        if not origin or not self.cors:
+            return False
+        from urllib.parse import urlparse
+        try:
+            parsed = urlparse(origin)
+            # Only allow http and https schemes
+            if parsed.scheme not in ('http', 'https'):
+                return False
+            return (parsed.scheme, parsed.netloc) in self.allowed_origins
+        except Exception:
+            return False
 
     def run(self, port, use_ssl, json):
         from http.server import HTTPServer
@@ -126,30 +164,6 @@ class RESTServer(Task):
         return "REST Server, ID %s" % self.id
 
 
-def _is_localhost_origin(origin):
-    """Check if an origin is a localhost origin (http://localhost:* or http://127.0.0.1:*).
-
-    Returns True if the origin is a localhost origin, False otherwise.
-    """
-    if not origin:
-        return False
-    from urllib.parse import urlparse
-    try:
-        parsed = urlparse(origin)
-        # Only allow http and https schemes
-        if parsed.scheme not in ('http', 'https'):
-            return False
-        # Check for localhost or 127.0.0.1
-        host = parsed.hostname
-        if host in ('localhost', '127.0.0.1'):
-            return True
-        # Also allow ::1 (IPv6 localhost)
-        if host == '::1':
-            return True
-        return False
-    except Exception:
-        return False
-
 
 class RESTHandler(BaseHTTPRequestHandler):
     """Process one REST request."""
@@ -171,8 +185,8 @@ class RESTHandler(BaseHTTPRequestHandler):
             return
 
         origin = self.headers.get("Origin")
-        if not _is_localhost_origin(origin):
-            self.send_error(403, "Forbidden: CORS only allowed for localhost origins")
+        if not self.server.chimerax_restserver._is_allowed_origin(origin):
+            self.send_error(403, "Forbidden: CORS only allowed for allowlisted origins")
             return
 
         self.send_response(200)
@@ -252,13 +266,13 @@ class RESTHandler(BaseHTTPRequestHandler):
         self.send_header("Content-Type", content_type)
         if length is not None:
             self.send_header("Content-Length", str(length))
-        # Add CORS headers if enabled and origin is localhost
-        if self.server.chimerax_restserver.cors:
-            origin = self.headers.get("Origin")
-            if _is_localhost_origin(origin):
-                self.send_header("Access-Control-Allow-Origin", origin)
-                self.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
-                self.send_header("Access-Control-Allow-Headers", "Content-Type")
+        # Add CORS headers if enabled and origin is allowlisted
+        origin = self.headers.get("Origin")
+        if self.server.chimerax_restserver._is_allowed_origin(origin):
+            self.send_header("Access-Control-Allow-Origin", origin)
+            self.send_header("Vary", "Origin")
+            self.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+            self.send_header("Access-Control-Allow-Headers", "Content-Type")
         self.end_headers()
 
     def _run(self, args):
@@ -338,11 +352,15 @@ class RESTHandler(BaseHTTPRequestHandler):
                 else:
                     q.put(rest_log.getvalue())
 
-        session.ui.thread_safe(f)
-        data = bytes(q.get(), "utf-8")
-        content_type = "application/json" if json else "text/plain"
-        self._header(200, content_type, len(data))
-        self.wfile.write(data)
+        origin = self.headers.get("Origin")
+        if self.server.chimerax_restserver._is_allowed_origin(origin):
+            session.ui.thread_safe(f)
+            data = bytes(q.get(), "utf-8")
+            content_type = "application/json" if json else "text/plain"
+            self._header(200, content_type, len(data))
+            self.wfile.write(data)
+        else:
+            self.send_error(403, "Forbidden: CORS only allowed for allowlisted origins")
 
 from chimerax.atomic import Structure, AtomicStructure, Chain, Atom, Bond, Residue
 try:


### PR DESCRIPTION
`remotecontrol start cors` now accepts true, false, or a comma-separated list of origins. Related to [this feature request](https://mail.cgl.ucsf.edu/mailman/archives/list/chimerax-users@cgl.ucsf.edu/thread/HOTBRLVZNMNJZNA65EZRY7RJGYRIGS2X/).

This includes a BREAKING CHANGE: requests that are not in the allowlist are no longer run. In the current version of ChimeraX, commands sent from a disallowed origin are still run, but the response does not include a CORS header. The wording of the old help text indicated that "Access-Control-Allow-Origin" is by default not sent for safety, making me think that the intent was to not allow execution of arbitrary code from disallowed origins. I'm happy to undo this change if allowing execution but not reply was the intended behavior.

I don't know if directly editing the HTML documentation files is the right way to go about it, let me know if there's a template or something somewhere else that I should change.

## To test

1. Launch ChimeraX
2. ChimeraX CLI: `remotecontrol rest start port 61312 cors true`
3. Terminal: `curl http://localhost:61312/run?command=windowsize -H "Origin:http://localhost"` -> information about ChimeraX window size
4. Terminal: `curl http://localhost:61312/run?command=exit -H "Origin:https://www.cgl.ucsf.edu/chimerax/"` -> Error 403, ChimeraX window remains open
5. ChimeraX CLI: `remotecontrol rest stop; remotecontrol rest start port 61312 cors https://example.com,https://www.cgl.ucsf.edu/chimerax/`
6. Terminal: `curl http://localhost:61312/run?command=windowsize -H "Origin:http://localhost"` -> Error 403
7. Terminal: `curl http://localhost:61312/run?command=exit -H "Origin:https://www.cgl.ucsf.edu/chimerax/"` -> ChimeraX exits